### PR TITLE
Jenkins integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Configuration:
         [test-pack]
         portal_url = https://COMPANYNAME.stb-tester.com
 
-2. Generate auth token.  See [Authentication] in the Stb-tester REST API
-   documentation.  You will need to enter this the first time you run the
+2. Generate access token. See [Authentication] in the Stb-tester REST API
+   documentation. You will need to enter this the first time you run the
    program.
 
 [Authentication]: https://stb-tester.com/manual/rest-api-v2#authentication
@@ -79,7 +79,7 @@ public API is the command-line interface.
     * Liberal MIT licence to remove any barriers to deployment.
     * It should have as few required dependencies as possible.  Currently it
       only requires `requests` and a `git` installation, with an
-      optional dependency on `keyring` for persisting the auth token.
+      optional dependency on `keyring` for persisting the access token.
 * Completeness - The whole of the stb-tester HTTP REST API should be exposed
 * Transparency - The Python API is intended to roughly have a 1 to 1
   correspondence with the REST API

--- a/README.md
+++ b/README.md
@@ -1,17 +1,35 @@
-# This is a work-in-progress.  The API is not yet stable and will change in future revisions.
+# stbt_rig.py
 
-# stbt-rig
-Python and command-line wrapper to the stb-tester REST API
+Command-line tool for interacting with the Stb-tester Portal's [REST API].
+
+[REST API]: https://stb-tester.com/manual/rest-api-v2
 
 <a href="https://travis-ci.org/stb-tester/stbt-rig">
   <img src="https://travis-ci.org/stb-tester/stbt-rig.png?branch=master">
 </a>
 
+## Interactive use
+
+`./stbt_rig.py --node-id=stb-tester-e5a091e40de1 run tests/file.py::test_name`
+will submit your local test-pack directory to run on an Stb-tester node. This
+saves you having to make lots of temporary git commits to debug your test
+scripts.
+
+## Jenkins integration
+
+The above command will detect if it is running inside a Jenkins job. If so, it
+will automatically read authentication credentials from the Jenkins Credentials
+Binding plugin, and it will record test results in the XML format expected by
+the Jenkins JUnit plugin.
+
+For instructions on setting up your Jenkins job see
+https://stb-tester.com/manual/continuous-integration
+
 ## Installation
 
-Copy `stbt_rig.py` into your test-pack.
+Copy `stbt_rig.py` into your test-pack, then install the necessary dependencies:
 
-### Windows
+#### Windows
 
 1. Install Python
 2. Install git
@@ -19,69 +37,46 @@ Copy `stbt_rig.py` into your test-pack.
 
         python -m pip install requests keyring
 
-### MacOS X
+#### MacOS X
 
-1. Install stbt-rig dependencies with setuptools:
+1. Install stbt-rig dependencies with Python setuptools:
 
         easy_install requests keyring
 
-### Linux Debian/Ubuntu
+#### Linux Debian/Ubuntu
 
 1. Install stbt-rig dependencies with apt:
 
         sudo apt-get install python-requests python-keyring
 
-## Setup
+## Configuration
 
 Configuration:
 
-1. Specify portal to use in `stbt.conf`:
+1. Specify portal to use in `.stbt.conf`:
 
         [test-pack]
-        portal_url = https://example.stb-tester.com
+        portal_url = https://COMPANYNAME.stb-tester.com
 
-2. Generate auth token.  See [Authentication] in the stb-tester REST API
+2. Generate auth token.  See [Authentication] in the Stb-tester REST API
    documentation.  You will need to enter this the first time you run the
    program.
 
 [Authentication]: https://stb-tester.com/manual/rest-api-v2#authentication
 
-# Usage
+## Design
 
-## Commandline Example
+#### Python API Goals
 
-Run a test:
-
-    $ stbt_rig.py --node-id stb-tester-e5a091e40de1 run tests/example.py::test_example
-
-## Python API Example
-
-Run a test:
-
-    import stbt_rig
-    
-    portal = stbt_rig.Portal("https://example.stb-tester.com", auth_token="abcdefghijklmnop")
-    node = stbt_rig.Node(portal, "stb-tester-e5a091e40de1")
-
-    job = node.run_tests(
-        test_pack_revision="master",
-        test_cases=["tests/example.py::test_example"],
-        await_completion=True)
-    if job.list_results()[0].is_ok():
-        print "SUCCESS"
-
-# Design
-
-## Python API Goals
+Note: The Python API exposed by this module isn't stable; for now the only
+public API is the command-line interface.
 
 * Portability - The library and command line client are intended to be portable
   to any Python version
 * Ease of deployment - it should be possible to `pip install` this or to just
   copy-and-paste it into other repos for reuse
-    * All the code should appear in a single stbt_rig.py should be a single
-      file.
-    * It's distributed under the liberal MIT licence to remove any barriers to
-      entry
+    * All the code should be in a single file (stbt_rig.py).
+    * Liberal MIT licence to remove any barriers to deployment.
     * It should have as few required dependencies as possible.  Currently it
       only requires `requests` and a `git` installation, with an
       optional dependency on `keyring` for persisting the auth token.
@@ -91,10 +86,12 @@ Run a test:
 * Robustness - The library should help with mitigate common network problems
     * Should include retries for HTTP failures
 
-## Commandline Client Goals
+#### Command-line Client Goals
 
 * Convenience for test-script development
 * Simple and robust CI system integration
+
+## TODO
 
 * [ ] Grab thumbnail - `/api/v2/nodes/(node_id)/thumbnail.jpg`
 * [ ] List test cases - `/api/v2/test_pack/<test_pack_sha>/test_case_names`
@@ -115,13 +112,10 @@ Run a test:
 * Get detailed information about a test run `/api/v2/results/(result_id)/`
     * [ ] Download artifacts
     * [ ] Artifact cache based on git sha headers?
-
-# TODO
-
 - [ ] Ensure that every REST API endpoint is covered
 - [ ] Add and publish API documentation
 - [ ] Decide on the best place to store REST API tokens
-- [ ] Add `requirements.txt` and publish on `pip`
+- [ ] Add `requirements.txt` and publish on PyPI
 - [ ] Don't let `requests` leak though the API
 - [ ] Raise appropriate exceptions for REST API errors
 - [ ] Retry logic

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -204,8 +204,7 @@ def cmd_run(args, node):
         commit_sha = args.test_pack_revision
     else:
         if args.mode == "interactive":
-            testpack = TestPack(remote=args.git_remote,
-                                verbosity=args.verbosity)
+            testpack = TestPack(remote=args.git_remote)
             commit_sha = testpack.push_git_snapshot(branch_name)
         elif args.mode == "jenkins":
             commit_sha = "master"
@@ -530,12 +529,11 @@ class NodeBusyException(Exception):
 
 
 class TestPack(object):
-    def __init__(self, root=None, remote="origin", verbosity=0):
+    def __init__(self, root=None, remote="origin"):
         if root is None:
             root = os.curdir
         self.root = root
         self.remote = remote
-        self.verbosity = verbosity
 
     def _git(self, cmd, capture_output=True, extra_env=None, **kwargs):
         if capture_output:
@@ -589,7 +587,7 @@ class TestPack(object):
     def push_git_snapshot(self, branch):
         commit_sha = self.take_snapshot()
         options = ['--force']
-        if self.verbosity <= 0:
+        if not logger.isEnabledFor(logging.DEBUG):
             options.append('--quiet')
         self._git(
             ['push'] + options +

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -223,6 +223,14 @@ def cmd_run(args, node):
             assert False, "Unreachable: Unknown mode %r" % args.mode
 
     tags = {}
+    if args.mode == "jenkins":
+        # Record Jenkins environment variables as tags.
+        # GIT_COMMIT or SVN_REVISION will refer to the repo of the STB software
+        # being tested in CI, rather than the test-pack repo.
+        for v in ["BUILD_ID", "BUILD_URL", "GIT_COMMIT", "JOB_NAME",
+                  "SVN_REVISION"]:
+            if os.environ.get(v):
+                tags["jenkins/%s" % v] = os.environ[v]
     for tag in args.tags:
         try:
             name, value = tag.split("=", 1)

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -184,7 +184,7 @@ def main(argv):
                 logger.error('Authentication failure with token "...%s"',
                              portal_auth_token[-8:])
             else:
-                message = "stbt-rig: HTTP %i Error: %s" % (
+                message = "HTTP %i Error: %s" % (
                     e.response.status_code, e.response.text)
                 if hasattr(e, "request"):
                     message += " during %s %s" % (

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -239,6 +239,8 @@ def cmd_run(args, node):
             die("Duplicate --tag name: %s" % name)
         tags[name] = value
 
+    logger.info("Running tests...")
+
     job = node.run_tests(
         commit_sha, args.test_cases, args.remote_control, category,
         args.soak, args.shuffle, tags, args.force, await_completion=True)
@@ -589,6 +591,7 @@ class TestPack(object):
         options = ['--force']
         if not logger.isEnabledFor(logging.DEBUG):
             options.append('--quiet')
+        logger.info("Pushing git snapshot to %s/%s", self.remote, branch)
         self._git(
             ['push'] + options +
             [self.remote,

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -258,6 +258,9 @@ def cmd_run(args, node):
         with open("stbt-results.xml", "w") as f:
             f.write(results_xml)
 
+    print "View these test results at: %s/app/#/results?filter=job:%s" % (
+        node.portal.url(), job.job_uid)
+
     if all(result.is_ok() for result in results):
         return 0
     else:

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -462,9 +462,6 @@ class Portal(object):
                 "Couldn't run test-job on node %s.  Node is currently in use.  "
                 "Specify --force to stop current job before running new one" %
                 node_id)
-        if not result.ok:
-            logger.warning("Running tests failed.  Server said:\n%s",
-                           result.content)
         result.raise_for_status()
         job = TestJob(self, job_json=result.json())
 

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -330,9 +330,8 @@ class Result(object):
 
 
 class TestJob(object):
-    class Status(object):
-        RUNNING = "running"
-        EXITED = "exited"
+    RUNNING = "running"
+    EXITED = "exited"
 
     def __init__(self, portal, job_uid=None, job_json=None):
         if job_uid is None and job_json is None:
@@ -350,7 +349,7 @@ class TestJob(object):
         self.stop()
 
     def stop(self):
-        if self.get_status() != TestJob.Status.EXITED:
+        if self.get_status() != TestJob.EXITED:
             self._post('/stop').raise_for_status()
 
     def await_completion(self, timeout=None):
@@ -362,7 +361,7 @@ class TestJob(object):
             if time.time() > end_time:
                 raise TimeoutException(
                     "Timeout waiting for job %s to complete" % self.job_uid)
-            if self.get_status() != TestJob.Status.RUNNING:
+            if self.get_status() != TestJob.RUNNING:
                 logger.debug("Job complete %s", self.job_uid)
                 return
             try:
@@ -387,9 +386,9 @@ class TestJob(object):
         if self._json.get('status') == 'exited':
             # If we were "exited" in the past, then we'll still be "exited" now:
             # Save making another HTTP request
-            return TestJob.Status.EXITED
+            return TestJob.EXITED
         self._update()
-        return TestJob.Status(self._json['status'])
+        return self._json['status']
 
     def _get(self, path="", **kwargs):
         r = self.portal._get(
@@ -424,7 +423,7 @@ class Node(object):
         response = self._get('job')
         response.raise_for_status()
         job = TestJob(self.portal, job_json=response.json())
-        if job.get_status() == TestJob.Status.RUNNING:
+        if job.get_status() == TestJob.RUNNING:
             job.stop()
 
     def press(self, key, test_pack_revision=None, remote_control=None):

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -190,6 +190,8 @@ def main(argv):
                     message += " during %s %s" % (
                         e.request.method, e.request.url)  # pylint:disable=no-member
                 die(message)
+        except NodeBusyException as e:
+            die(str(e))
 
     # Authentication error and no further tokens
     return 1

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -193,6 +193,9 @@ def main(argv):
                         e.request.method, e.request.url)  # pylint:disable=no-member
                 die(message)
 
+    # Authentication error and no further tokens
+    return 1
+
 
 def cmd_run(args, testpack, node):
     commit_sha = testpack.push_git_snapshot()

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -11,6 +11,7 @@ import ConfigParser
 import logging
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -144,6 +145,10 @@ def main(argv):
 
     args = parser.parse_args(argv[1:])
 
+    signal.signal(signal.SIGINT, _exit)
+    signal.signal(signal.SIGTERM, _exit)
+    signal.signal(signal.SIGHUP, _exit)
+
     logging.basicConfig(
         format="%(filename)s: %(levelname)s: %(message)s",
         level=logging.WARNING - args.verbosity * 10)
@@ -195,6 +200,14 @@ def main(argv):
 
     # Authentication error and no further tokens
     return 1
+
+
+def _exit(signo, _):
+    logger.warning("Received %s. Stopping job.",
+                   {signal.SIGINT: "SIGINT", signal.SIGTERM: "SIGTERM",
+                    signal.SIGHUP: "SIGHUP"}[signo])
+    # Teardown is handled by TestJob.__exit__
+    sys.exit(0)
 
 
 def cmd_run(args, node):

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -234,16 +234,16 @@ def iter_portal_auth_tokens(portal_url, portal_auth_file, mode):
 
     assert mode == "interactive", "Unreachable: Unknown mode %s" % mode
 
-    while True:
-        keyring = None
-        try:
-            import keyring
-            out = keyring.get_password(portal_url, "")
-            if out:
-                yield out
-        except ImportError:
-            pass
+    keyring = None
+    try:
+        import keyring
+        out = keyring.get_password(portal_url, "")
+        if out:
+            yield out
+    except ImportError:
+        pass
 
+    while True:
         sys.stderr.write('Enter Token for portal %r: ' % portal_url)
         token = sys.stdin.readline().strip()
         if token:


### PR DESCRIPTION
Extend the command-line API so that it is convenient for using from Jenkins; and polish the help & documentation to a releasable state.

For now we've descoped the Python API completely; the only public API is the command-line interface.

TODO:

- [x] Flesh out command-line API.
- [x] Implement it.
- [x] Test interactive mode.
- [x] Test jenkins mode.
- [ ] Write instructions for Jenkins job configuration.
