### PR TITLE
Windows portability: There's no SIGHUP on Windows

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -178,7 +178,8 @@ def main(argv):
 
     signal.signal(signal.SIGINT, _exit)
     signal.signal(signal.SIGTERM, _exit)
-    signal.signal(signal.SIGHUP, _exit)
+    if hasattr(signal, "SIGHUP"):
+        signal.signal(signal.SIGHUP, _exit)
 
     logging.basicConfig(
         format="%(filename)s: %(levelname)s: %(message)s",


### PR DESCRIPTION
This fixes "AttributeError: 'module' object has no attribute 'SIGHUP'".

Furthermore, the Python documentation for [`signal.signal()`][1] says:

> On Windows, signal() can only be called with SIGABRT, SIGFPE, SIGILL,
> SIGINT, SIGSEGV, or SIGTERM. A ValueError will be raised in any other
> case.

[1]: https://docs.python.org/2.7/library/signal.html#signal.signal