### PR TITLE
Fix reauth when using invalid token in interactive mode

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -243,7 +243,9 @@ def _exit(signo, _):
 
 def cmd_run(args, node):
     if args.mode == "interactive":
-        username = node.portal._get("/api/v2/user").json()["login"]
+        response = node.portal._get("/api/v2/user")
+        response.raise_for_status()
+        username = response.json()["login"]
         branch_name = "%s/snapshot" % username
 
     if args.test_pack_revision:


### PR DESCRIPTION
We use an "optimistic" approach to auth.  This means that we make whatever
HTTP call we want and we only ask the user for authentication details if
it fails with 403.  We depend on requests' `raise_for_status()` raising an
HTTPError (403) to signal this failure.

This adds raise_for_status for our first API call in interactive mode.
Otherwise you get:

    Traceback (most recent call last):
      File "./stbt_rig.py", line 695, in <module>
        sys.exit(main(sys.argv))
      File "./stbt_rig.py", line 213, in main
        return cmd_run(args, node)
      File "./stbt_rig.py", line 246, in cmd_run
        username = node.portal._get("/api/v2/user").json()["login"]
      File "/usr/lib/python2.7/dist-packages/requests/models.py", line 894, in json
        return complexjson.loads(self.text, **kwargs)
      File "/usr/lib/python2.7/dist-packages/simplejson/__init__.py", line 517, in loads
        return _default_decoder.decode(s)
      File "/usr/lib/python2.7/dist-packages/simplejson/decoder.py", line 370, in decode
        obj, end = self.raw_decode(s)
      File "/usr/lib/python2.7/dist-packages/simplejson/decoder.py", line 400, in raw_decode
        return self.scan_once(s, idx=_w(s, idx).end())
    simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Rather than:

    stbt_rig.py: ERROR: Authentication failure with token "...xxxxxxxx"
    Enter Access Token for portal https://xxxxx.stb-tester.com: