### PR TITLE
Shorten the untracked files warning and unit tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,8 @@
 install:
-  - cmd: python.exe -m pip install keyring requests pylint==1.5.2 astroid==1.4.4
+  - cmd: python.exe -m pip install keyring pytest requests pylint==1.5.2 astroid==1.4.4
 
 build: off
 
 test_script:
   - cmd: pylint stbt_rig.py
+  - cmd: py.test -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 
 install:
 - cat /etc/os-release
-- sudo apt install python-keyring python-requests
-- sudo pip install pylint==1.5.2 astroid==1.4.4
+- pip install keyring pylint==1.5.2 pytest requests astroid==1.4.4
 
 script:
 - pylint stbt_rig.py
+- py.test -vv

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -699,12 +699,15 @@ class TestPack(object):
     def take_snapshot(self):
         status = [(x[0:2], x[3:])
                   for x in self._git(['status', '-z']).split('\0')]
-        for status_code, filename in status:
-            if status_code == '??':
-                logging.warning(
-                    'Snapshotting git repo: Ignoring untracked file %s.  '
-                    'Either add it (with git add) or add it to .gitignore',
-                    filename)
+        untracked_files = [filename for status_code, filename in status
+                           if status_code == "??"]
+        if untracked_files:
+            sys.stderr.write("stbt-rig: Warning: Ignoring untracked files:\n\n")
+            for filename in untracked_files:
+                sys.stderr.write("    %s\n" % filename)
+            sys.stderr.write(
+                '\nTo avoid this warning add untracked files (with "git add") '
+                'or add them to .gitignore\n')
 
         base_commit = self.get_sha(obj_type="commit")
 

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -740,12 +740,13 @@ class TestPack(object):
 
 
 @contextmanager
-def named_temporary_directory(suffix='', prefix='tmp', dir=None):
+def named_temporary_directory(suffix='', prefix='tmp', dir=None,
+                              ignore_errors=False):
     dirname = tempfile.mkdtemp(suffix, prefix, dir)
     try:
         yield dirname
     finally:
-        shutil.rmtree(dirname)
+        shutil.rmtree(dirname, ignore_errors=ignore_errors)
 
 
 def die(message, *args):

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+from contextlib import contextmanager
+from textwrap import dedent
+
+import pytest
+
+import stbt_rig
+
+
+@pytest.fixture(scope="function", name="tmpdir")
+def fixture_tmpdir():
+    with stbt_rig.named_temporary_directory(ignore_errors=True) as d:
+        origdir = os.path.abspath(os.curdir)
+        try:
+            os.chdir(d)
+            yield d
+        finally:
+            os.chdir(origdir)
+
+
+@pytest.fixture(scope="function", name="test_pack")
+def fixture_test_pack(tmpdir):  # pylint: disable=unused-argument
+    subprocess.check_call(['git', 'init'])
+    subprocess.check_call([
+        'git', 'config', 'user.email', 'stbt-rig@stb-tester.com'])
+    subprocess.check_call(['git', 'config', 'user.name', 'stbt-rig tests'])
+
+    with open("moo", 'w') as f:
+        f.write("Hello!\n")
+    subprocess.check_call(['git', 'add', 'moo'])
+    subprocess.check_call(['git', 'commit', '-m', 'Test'])
+
+    return stbt_rig.TestPack()
+
+
+def test_testpack_snapshot_no_change_if_no_commits(test_pack):
+    with assert_status_unmodified():
+        assert rev_parse("HEAD") == test_pack.take_snapshot()
+
+
+@contextmanager
+def assert_status_unmodified():
+    pre_status = subprocess.check_output(["git", "status"])
+    yield
+    post_status = subprocess.check_output(["git", "status"])
+    assert pre_status == post_status
+
+
+def cat(revision, filename):
+    return subprocess.check_output(
+        ['git', 'cat-file', 'blob', "%s:%s" % (revision, filename)])
+
+
+def rev_parse(revision):
+    return subprocess.check_output(
+        ['git', 'rev-parse', '--verify', revision]).strip()
+
+
+def test_testpack_snapshot_contains_modifications(test_pack):
+    with open("moo", "w") as f:
+        f.write("Goodbye!\n")
+
+    with assert_status_unmodified():
+        ss = test_pack.take_snapshot()
+        assert ss != rev_parse("HEAD")
+        assert rev_parse("%s~1" % ss) == rev_parse("HEAD")
+        assert cat(ss, 'moo') == "Goodbye!\n"
+        assert cat("HEAD", 'moo') == "Hello!\n"
+
+
+def test_testpack_snapshot_with_untracked_files(test_pack):
+    with open("other", "w") as f:
+        f.write("It's uncommitted\n")
+
+    with assert_status_unmodified():
+        orig_sha = rev_parse("HEAD")
+        ss = test_pack.take_snapshot()
+        # Untracked files aren't included in the snapshot:
+        assert orig_sha == ss

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -69,7 +69,8 @@ def test_testpack_snapshot_contains_modifications(test_pack):
         assert cat("HEAD", 'moo') == "Hello!\n"
 
 
-def test_testpack_snapshot_with_untracked_files(test_pack):
+def test_testpack_snapshot_with_untracked_files(test_pack, capsys):
+    assert capsys.readouterr() == ("", "")
     with open("other", "w") as f:
         f.write("It's uncommitted\n")
 
@@ -78,3 +79,11 @@ def test_testpack_snapshot_with_untracked_files(test_pack):
         ss = test_pack.take_snapshot()
         # Untracked files aren't included in the snapshot:
         assert orig_sha == ss
+
+    assert capsys.readouterr() == ("", dedent("""\
+        stbt-rig: Warning: Ignoring untracked files:
+
+            other
+
+        To avoid this warning add untracked files (with "git add") or add them to .gitignore
+        """))


### PR DESCRIPTION
This makes it easier to read the output on my terminal, because the lines don't wrap so there's one line per untracked file.

Based on the original idea by @drothlis in #9.  The differences are:

* Write to ~~stdout~~stderr rather than via `logging.warning` for prettier output
* Don't repeat text "Ignoring untracked file" before each filename
* Tests