### PR TITLE
Change hashbang from "python2" to "python" for MacOS compatibility

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """Command-line tool for interacting with the Stb-tester Portal's REST API.
 


### PR DESCRIPTION
There is no "python2" binary on Mac systems by default, it's just called
"python".