### PR TITLE
Add pytest integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - cmd: python.exe -m pip install keyring requests pytest pylint==1.9.3 astroid==1.6.5
+  - cmd: python.exe -m pip install keyring requests pytest pylint==1.9.3 astroid==1.6.5 flask==1.0.2 werkzeug==0.14.1
 
 build: off
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -28,6 +28,9 @@ disable=
   too-many-return-statements,
   too-many-statements,
 
+[TYPECHECK]
+ignored-classes=Args
+
 [FORMAT]
 max-line-length=80
 ignore-long-lines=https?://

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 install:
 - cat /etc/os-release
-- pip install keyring requests pytest pylint==1.9.3 astroid==1.6.5
+- pip install keyring requests pytest pylint==1.9.3 astroid==1.6.5 flask==1.0.2 werkzeug==0.14.1
 
 script:
 - pylint stbt_rig.py

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -962,7 +962,7 @@ try:
             with open(self.name) as f:
                 # We implement our own parsing to avoid import stbt ImportErrors
                 for line in f:
-                    m = re.match(r'def (test_.*)\s*\(\):\s*$', line)
+                    m = re.match(r'^def\s+(test_[a-zA-Z0-9_]*)', line)
                     if m:
                         yield StbtRemoteTest(self, self.name, m.group(1))
 

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -532,7 +532,7 @@ def find_test_pack_root():
             return root
         root = os.path.split(root)[0]
     raise NotInTestPack(
-        """Didn't find "stbt.conf" at the root of your test-pack """
+        """Didn't find ".stbt.conf" at the root of your test-pack """
         """(starting at %s)""" % os.getcwd())
 
 

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -236,13 +236,6 @@ def test_run_tests_interactive(capsys, test_pack, tmpdir, portal_mock):
 
 
 def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
-    import platform
-    if platform.system() == "Windows":
-        # On appveyor the check_call fails because it can't find py.test.  I'm
-        # sure this is fixable but I don't have a Windows environment to play
-        # with it right now.
-        pytest.skip()
-
     with open('token', 'w') as f:
         f.write("this is my token")
     portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
@@ -250,7 +243,7 @@ def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
     env = os.environ.copy()
     env['PYTHONPATH'] = os.path.dirname(os.path.abspath(__file__))
     subprocess.check_call([
-        'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
+        'python', '-m', 'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
         '--portal-url=%s' % portal_mock.url, '--portal-auth-file=token',
         '--node-id=mynode', 'tests/test.py::test_my_tests'], env=env)
 
@@ -258,6 +251,6 @@ def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
     portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
                                  node_id="mynode")
     subprocess.check_call([
-        'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
+        'python', '-m', 'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
         '--portal-url=%s' % portal_mock.url, '--portal-auth-file=../token',
         '--node-id=mynode', 'test.py::test_my_tests'], env=env)

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -195,7 +195,8 @@ class PortalMock(object):
 
     def on_run_tests(self, j):
         expected = self.expectations.pop(0)
-        assert all(j[k] == v for k, v in expected.items())
+        for k, v in expected.items():
+            assert j[k] == v
         return {'job_uid': '/mynode/6Pfq/167'}
 
 
@@ -226,6 +227,13 @@ def test_run_tests_interactive(capsys, test_pack, tmpdir, portal_mock):
         'stbt_rig.py', '--node-id=mynode', '--portal-url=%s' % portal_mock.url,
         '--portal-auth-file=token', 'run', 'tests/test.py::test_my_tests'])
 
+    os.chdir('tests')
+    portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
+                                 node_id="mynode")
+    assert 0 == stbt_rig.main([
+        'stbt_rig.py', '--node-id=mynode', '--portal-url=%s' % portal_mock.url,
+        '--portal-auth-file=../token', 'run', 'test.py::test_my_tests'])
+
 
 def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
     import platform
@@ -245,3 +253,11 @@ def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
         'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
         '--portal-url=%s' % portal_mock.url, '--portal-auth-file=token',
         '--node-id=mynode', 'tests/test.py::test_my_tests'], env=env)
+
+    os.chdir('tests')
+    portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
+                                 node_id="mynode")
+    subprocess.check_call([
+        'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
+        '--portal-url=%s' % portal_mock.url, '--portal-auth-file=../token',
+        '--node-id=mynode', 'test.py::test_my_tests'], env=env)

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -221,12 +221,6 @@ def test_run_tests_interactive(capsys, test_pack, tmpdir, portal_mock):
         """) % portal_mock.url
     assert capsys.readouterr().out[-len(expected_stdout):] == expected_stdout
 
-    portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
-                                 node_id="mynode")
-    assert 0 == stbt_rig.main([
-        'stbt_rig.py', '--node-id=mynode', '--portal-url=%s' % portal_mock.url,
-        '--portal-auth-file=token', 'run', 'tests/test.py::test_my_tests'])
-
     os.chdir('tests')
     portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
                                  node_id="mynode")


### PR DESCRIPTION
So you can run tests like:

    PYTHONPATH=$PWD py.test \
        -p stbt_rig -p no:python \
        --node-id=stb-tester-00044b012345 \
        tests/roku.py::test_that_it_works

This is useful because a lot of other tools integrate with pytest - which
now means they integrate with stbt_rig.  In particular I've written this
for pycharm integration.

This isn't perfect.  We run each test specified on the command line in a separate job.  I think we should be able to do it in one job, but I'm not sure how right now.  But I think this will be fine for now.  The pycharm click to run this test integration case only requires running a single test anyhow.