### PR TITLE
Retry HTTP requests for robustness

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - cmd: python.exe -m pip install keyring requests pytest pylint==1.9.3 astroid==1.6.5 flask==1.0.2 werkzeug==0.14.1
+  - cmd: python.exe -m pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.0.2 werkzeug==0.14.1
 
 build: off
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 install:
 - cat /etc/os-release
-- pip install keyring requests pytest pylint==1.9.3 astroid==1.6.5 flask==1.0.2 werkzeug==0.14.1
+- pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.0.2 werkzeug==0.14.1
 
 script:
 - pylint stbt_rig.py

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -845,10 +845,10 @@ class Portal(object):
             job.await_completion(timeout=timeout)
             return job
 
-    def _get(self, endpoint, **kwargs):
-        return self._session.get(self.url(endpoint), **kwargs)
+    def _get(self, endpoint, timeout=60, **kwargs):
+        return self._session.get(self.url(endpoint), timeout=timeout, **kwargs)
 
-    def _post(self, endpoint, json=None, headers=None, **kwargs):  # pylint:disable=redefined-outer-name
+    def _post(self, endpoint, json=None, headers=None, timeout=60, **kwargs):  # pylint:disable=redefined-outer-name
         from json import dumps
         if headers is None:
             headers = {}
@@ -859,7 +859,8 @@ class Portal(object):
         if json is not None:
             headers['Content-Type'] = 'application/json'
             kwargs['data'] = dumps(json)
-        r = self._session.post(self.url(endpoint), headers=headers, **kwargs)
+        r = self._session.post(
+            self.url(endpoint), headers=headers, timeout=timeout, **kwargs)
         return r
 
 

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -793,10 +793,13 @@ class Node(object):
 class Portal(object):
     def __init__(self, url, auth_token, readonly=False):
         self._url = url
-        self._auth_token = auth_token
         self.readonly = readonly
-        self._session = requests.session()
-        self._session.headers.update({"User-Agent": "stbt-rig"})
+
+        session = requests.session()
+        session.headers.update({
+            "Authorization": "token %s" % auth_token,
+            "User-Agent": "stbt-rig"})
+        self._session = session
 
     def url(self, endpoint=""):
         if endpoint.startswith(self._url):
@@ -842,17 +845,13 @@ class Portal(object):
             job.await_completion(timeout=timeout)
             return job
 
-    def _get(self, endpoint, headers=None, **kwargs):
-        if headers is None:
-            headers = {}
-        headers["Authorization"] = "token %s" % self._auth_token
-        return self._session.get(self.url(endpoint), headers=headers, **kwargs)
+    def _get(self, endpoint, **kwargs):
+        return self._session.get(self.url(endpoint), **kwargs)
 
     def _post(self, endpoint, json=None, headers=None, **kwargs):  # pylint:disable=redefined-outer-name
         from json import dumps
         if headers is None:
             headers = {}
-        headers["Authorization"] = "token %s" % self._auth_token
         if self.readonly:
             raise RuntimeError(
                 "Not allowed to mutate this TestRunner, please use a different "

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -695,12 +695,13 @@ class TestJob(object):
             if time.time() > end_time:
                 raise TimeoutException(
                     "Timeout waiting for job %s to complete" % self.job_uid)
-            if self.get_status() != TestJob.RUNNING:
+            if self.get_status(timeout=min(end_time - time.time(), 600)) != \
+                    TestJob.RUNNING:
                 logger.debug("Job complete %s", self.job_uid)
                 return
             try:
                 self._get('/await_completion',
-                          timeout=min(end_time - time.time(), 60))
+                          timeout=min(end_time - time.time(), 600))
             except requests.exceptions.Timeout:
                 pass
 
@@ -722,12 +723,12 @@ class TestJob(object):
         r.raise_for_status()
         return r.content
 
-    def get_status(self):
+    def get_status(self, timeout=60):
         if self._json.get('status') == 'exited':
             # If we were "exited" in the past, then we'll still be "exited" now:
             # Save making another HTTP request
             return TestJob.EXITED
-        self._update()
+        self._json = self._get(timeout=timeout).json()
         return self._json['status']
 
     def _get(self, path="", **kwargs):
@@ -741,9 +742,6 @@ class TestJob(object):
             '/api/v2/jobs%s%s' % (self.job_uid, path), **kwargs)
         r.raise_for_status()
         return r
-
-    def _update(self):
-        self._json = self._get().json()
 
 
 class TimeoutException(RuntimeError):
@@ -799,7 +797,8 @@ class Portal(object):
         session.headers.update({
             "Authorization": "token %s" % auth_token,
             "User-Agent": "stbt-rig"})
-        self._session = session
+        self._session = RetrySession(
+            timeout=1e9, session=session, logger=logger)
 
     def url(self, endpoint=""):
         if endpoint.startswith(self._url):
@@ -938,6 +937,84 @@ class TestPack(object):
             [self.remote,
              '%s:refs/heads/%s' % (commit_sha, branch)])
         return commit_sha
+
+
+class RetrySession(object):
+    """
+    Emulates a requests session but with retry and timeout logic for a sequence
+    of HTTP requests.
+    """
+    def __init__(self, timeout, session=None, interval=1,
+                 logger=logging.getLogger('retry_session'),  # pylint: disable=redefined-outer-name
+                 _time=None):
+        if session is None:
+            session = requests.Session()
+        if _time is None:
+            _time = time
+
+        self._time = _time
+        self._session = session
+        self._end_time = self._time.time() + timeout
+        self._interval = interval
+        self._logger = logger
+
+    def put(self, url, data=None, **kwargs):
+        return self.request('put', url, data=data, **kwargs)
+
+    def post(self, url, data=None, json=None, **kwargs):
+        return self.request('post', url, data=data, json=json, **kwargs)
+
+    def get(self, url, params=None, **kwargs):
+        kwargs.setdefault('allow_redirects', True)
+        return self.request('get', url, params=params, **kwargs)
+
+    def request(self, method, url, timeout=None, **kwargs):
+        last_exc_info = (None, None, None)
+        if timeout:
+            end_time = self._time.time() + timeout
+        else:
+            end_time = self._end_time
+        # We'll double interval below:
+        interval = self._interval / 2.
+        while True:
+            now = self._time.time()
+            if now >= end_time:
+                self._logger.warning(
+                    "Timed out making request %s %s", method, url,
+                    exc_info=last_exc_info)
+                if last_exc_info[0] is not None:
+                    raise last_exc_info[0], last_exc_info[1], last_exc_info[2]  # pylint: disable=raising-bad-type
+                else:
+                    raise RetryTimeout()
+
+            # We have a global timeout: we don't want any single request to
+            # take longer than 1/2 of the time remaining to allow for retries
+            kwargs.setdefault('timeout', max((end_time - now) / 2, 1))
+            response = None
+            try:
+                response = self._session.request(method, url, **kwargs)
+                # Success or 4xx client error: don't retry:
+                if response.status_code < 500:
+                    # Avoid traceback circular references:
+                    del last_exc_info
+                    return response
+                response.raise_for_status()
+            except requests.RequestException as e:
+                # Exponential backoff up to 30s
+                interval = max(
+                    self._interval,
+                    min(interval * 2, 30, end_time - time.time() - 1))
+                self._logger.info(
+                    "request %s %s failed.  Will retry in %is", method, url,
+                    interval, exc_info=True)
+                if e.response:
+                    self._logger.info('Got response %r', e.response.text)
+                last_exc_info = sys.exc_info()
+                self._time.sleep(interval)
+
+
+class RetryTimeout(requests.exceptions.Timeout):
+    pass
 
 
 try:

--- a/test_retry_session.py
+++ b/test_retry_session.py
@@ -1,0 +1,108 @@
+import logging
+from collections import namedtuple
+from contextlib import contextmanager
+
+import requests
+
+from stbt_rig import RetrySession
+
+
+RetrySessionTestCtx = namedtuple(
+    "RetrySessionTestCtx", "http_mock session time")
+
+
+@contextmanager
+def retry_session_test_ctx():
+    import requests_mock
+
+    time_ = MockTime()
+    session = requests.Session()
+    adapter = requests_mock.Adapter()
+    session.mount('mock', adapter)
+
+    retrysession = RetrySession(10, session=session, _time=time_)
+    yield RetrySessionTestCtx(adapter, retrysession, time_)
+
+
+def test_retrysession_happypath():
+    with retry_session_test_ctx() as ctx:
+        ctx.http_mock.register_uri('GET', '//test.com/path', text='resp')
+        with ctx.time.assert_duration(seconds=0):
+            assert ctx.session.get('mock://test.com/path').text == 'resp'
+
+
+def test_retrysession_retry_after_500():
+    with retry_session_test_ctx() as ctx:
+        ctx.http_mock.register_uri(
+            'GET', '//test.com/path', [
+                {'text': 'bad', 'status_code': 500},
+                {'text': 'ok', 'status_code': 200},
+            ])
+        with ctx.time.assert_duration(seconds=1):
+            assert ctx.session.get('mock://test.com/path').text == 'ok'
+
+
+def test_retrysession_no_retry_after_400():
+    with retry_session_test_ctx() as ctx:
+        ctx.http_mock.register_uri(
+            'GET', '//test.com/path', [
+                {'text': 'bad', 'status_code': 400},
+                {'text': 'ok', 'status_code': 200},
+            ])
+        with ctx.time.assert_duration(seconds=0):
+            resp = ctx.session.get('mock://test.com/path')
+            assert resp.text == 'bad'
+            assert resp.status_code == 400
+
+
+def test_retrysession_timeout():
+    with retry_session_test_ctx() as ctx:
+        ctx.http_mock.register_uri(
+            'GET', '//test.com/path', text='bad', status_code=500)
+        with ctx.time.assert_duration(seconds=10):
+            try:
+                ctx.session.get('mock://test.com/path')
+                assert False, "GET should have thrown"
+            except requests.HTTPError as e:
+                assert e.response.text == 'bad'
+                assert e.response.status_code == 500
+
+
+class MockTime(object):
+    def __init__(self, start_time=1500000000.):
+        self._time = start_time
+        self._functions = []
+
+    def time(self):
+        t = self._time
+        return t
+
+    def sleep(self, seconds):
+        logging.info("time.sleep(%s)", seconds)
+        while self._functions and self._functions[0][0] <= self._time + seconds:
+            _, fn = self._functions.pop(0)
+            fn()
+
+        self._time += seconds
+
+    def interrupt(self, exception):
+        def raise_exception():
+            raise exception
+        self.at(0, raise_exception)
+
+    def at(self, offset, function):
+        self._functions.append((self._time + offset, function))
+        self._functions.sort()
+
+    @contextmanager
+    def assert_duration(self, seconds):
+        start_time = self._time
+        yield self
+        assert self._time - start_time == seconds
+
+    @contextmanager
+    def patch(self):
+        from mock import patch
+        with patch("time.time", self.time), \
+                patch("time.sleep", self.sleep):
+            yield self


### PR DESCRIPTION
We retry on requests exceptions and 5xx errors.  This allows for temporary network interruption and portal downtime of up to 10min.

TODO

- [x] Automated tests.
- [x] Audit each request to see if retrys could cause problems.
- [x] Debug "branch_name used before initialisation" bug. #23 
- [ ] Consider what is the correct behaviour if the node is offline - portal will return 503 (Service Unavailable) for node offline which will get retried.