### PR TITLE
stbt-rig: Only stop long-running jobs on SIGINT/SIGTERM/SIGHUP

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,6 +8,7 @@ reports=no
 
 [MESSAGES CONTROL]
 disable=
+  global-statement,
   invalid-name,
   locally-disabled,
   locally-enabled,

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -37,6 +37,7 @@ except ImportError:
         pass
 
 
+killed = False
 logger = logging.getLogger("stbt_rig")
 
 
@@ -374,6 +375,8 @@ def argparser():
 
 
 def _exit(signo, _):
+    global killed
+    killed = True
     name = next(k for k, v in signal.__dict__.iteritems()
                 if v == signo and "_" not in k)
     logger.warning("Received %s. Stopping job.", name)
@@ -676,7 +679,8 @@ class TestJob(object):
         return self
 
     def __exit__(self, _1, _2, _3):
-        self.stop()
+        if killed:
+            self.stop()
 
     def stop(self):
         if self.get_status() != TestJob.EXITED:


### PR DESCRIPTION
Exceptions (such as an intermittent network connection error from
`await_completion`) won't cause the job to be stopped. Ideally we should
handle those exceptions explicitly, but this is a backstop solution.