### PR TITLE
stop: Handle jobs that take a long time to stop

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1102,7 +1102,7 @@ class RetrySession(object):
 
     def request(self, method, url, timeout=None, retry=None, **kwargs):
         last_exc_info = (None, None, None)
-        if timeout:
+        if timeout is not None:
             end_time = self._time.time() + timeout
         else:
             end_time = self._end_time

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1126,8 +1126,15 @@ class RetrySession(object):
                     raise RetryTimeout()
 
             # We have a global timeout: we don't want any single request to
-            # take longer than 1/2 of the time remaining to allow for retries
-            kwargs.setdefault('timeout', max((end_time - now) / 2, 1))
+            # take longer than 1/2 of the time remaining to allow for retries.
+            #
+            # We also place a limit of 60s.  Requests to the portal should
+            # time-out in less time than this anyway.  The risk of a longer
+            # timeout is that the connection gets dropped silently by a some
+            # middlebox and we wait for ages when we're never going to get a
+            # response.
+            timeout = min(60, max((end_time - now) / 2, 1))
+            kwargs.setdefault('timeout', timeout)
             response = None
             try:
                 response = self._session.request(method, url, **kwargs)

--- a/test_retry_session.py
+++ b/test_retry_session.py
@@ -45,6 +45,17 @@ def test_retrysession_retry_after_500():
             assert ctx.session.get('mock://test.com/path').text == 'ok'
 
 
+def test_retrysession_retry_after_202():
+    with retry_session_test_ctx() as ctx:
+        ctx.http_mock.register_uri(
+            'GET', '//test.com/path', [
+                {'text': 'retry', 'status_code': 202},
+                {'text': 'ok', 'status_code': 200},
+            ])
+        with ctx.time.assert_duration(seconds=0):
+            assert ctx.session.get('mock://test.com/path').text == 'ok'
+
+
 def test_retrysession_no_retry_after_400():
     with retry_session_test_ctx() as ctx:
         ctx.http_mock.register_uri(

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -4,6 +4,7 @@ import glob
 import logging
 import os
 import platform
+import random
 import re
 import socket
 import threading
@@ -169,6 +170,10 @@ class PortalMock(object):
         @self.app.route('/api/v2/jobs/mynode/6Pfq/167')
         def get_job():
             return flask.jsonify({'status': 'exited'})
+
+        @self.app.route('/api/v2/jobs/mynode/6Pfq/167/await_completion')
+        def await_completion():
+            return "{}", random.choice([200, 202, 202, 202])
 
         @self.app.route('/api/v2/results')
         def get_results():


### PR DESCRIPTION
For nodes on a slow network connection you can get a buildup of
pending result uploads.  This can cause `/stop` to take a long time
to return and to potentially timeout after 55s with status code
202.  This new code handles that condition by retrying if that
happens.