### PR TITLE
Python 3 compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - cmd: python.exe -m pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.0.2 werkzeug==0.14.1
+  - cmd: python.exe -m pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.1.1 werkzeug==0.15.5
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,4 +5,4 @@ build: off
 
 test_script:
   - cmd: pylint stbt_rig.py
-  - cmd: py.test -vv
+  - cmd: pytest -vv

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ environment:
     - PYTHON: "C:\\Python36-x64"
 
 install:
-  - cmd: "%PYTHON%\\python.exe -m pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.1.1 werkzeug==0.15.5"
+  - cmd: "%PYTHON%\\python.exe -m pip install -r requirements.txt"
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,13 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python36-x64"
+
 install:
-  - cmd: python.exe -m pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.1.1 werkzeug==0.15.5
+  - cmd: "%PYTHON%\\python.exe -m pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.1.1 werkzeug==0.15.5"
 
 build: off
 
 test_script:
-  - cmd: pylint stbt_rig.py
-  - cmd: pytest -vv
+  - cmd: "%PYTHON%\\Scripts\\pylint.exe stbt_rig.py"
+  - cmd: "%PYTHON%\\Scripts\\pytest.exe -vv"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
 - cat /etc/os-release
-- pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.1.1 werkzeug==0.15.5
+- pip install -r requirements.txt
 
 script:
 - pylint stbt_rig.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
 - cat /etc/os-release
-- pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.0.2 werkzeug==0.14.1
+- pip install keyring requests requests-mock pytest pylint==1.9.3 astroid==1.6.5 flask==1.1.1 werkzeug==0.15.5
 
 script:
 - pylint stbt_rig.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
 
 script:
 - pylint stbt_rig.py
-- py.test -vv
+- pytest -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.6'
 
 install:
 - cat /etc/os-release

--- a/Dockerfile.python2
+++ b/Dockerfile.python2
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt update && \
+    apt install -y \
+        git \
+        python-pip && \
+    pip install \
+        keyring \
+        requests \
+        requests-mock \
+        pytest \
+        pylint==1.9.3 \
+        astroid==1.6.5 \
+        flask==1.0.2 \
+        werkzeug==0.14.1

--- a/Dockerfile.python2
+++ b/Dockerfile.python2
@@ -11,5 +11,5 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         pytest \
         pylint==1.9.3 \
         astroid==1.6.5 \
-        flask==1.0.2 \
-        werkzeug==0.14.1
+        flask==1.1.1 \
+        werkzeug==0.15.5

--- a/Dockerfile.python2
+++ b/Dockerfile.python2
@@ -1,15 +1,9 @@
 FROM ubuntu:18.04
+ADD requirements.txt requirements.txt
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt update && \
     apt install -y \
         git \
         python-pip && \
-    pip install \
-        keyring \
-        requests \
-        requests-mock \
-        pytest \
-        pylint==1.9.3 \
-        astroid==1.6.5 \
-        flask==1.1.1 \
-        werkzeug==0.15.5
+    pip install -r requirements.txt && \
+    rm requirements.txt

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -11,5 +11,5 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         pytest \
         pylint==1.9.3 \
         astroid==1.6.5 \
-        flask==1.0.2 \
-        werkzeug==0.14.1
+        flask==1.1.1 \
+        werkzeug==0.15.5

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -1,15 +1,9 @@
 FROM ubuntu:18.04
+ADD requirements.txt requirements.txt
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt update && \
     apt install -y \
         git \
         python3-pip && \
-    pip3 install \
-        keyring \
-        requests \
-        requests-mock \
-        pytest \
-        pylint==1.9.3 \
-        astroid==1.6.5 \
-        flask==1.1.1 \
-        werkzeug==0.15.5
+    pip3 install -r requirements.txt && \
+    rm requirements.txt

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt update && \
+    apt install -y \
+        git \
+        python3-pip && \
+    pip3 install \
+        keyring \
+        requests \
+        requests-mock \
+        pytest \
+        pylint==1.9.3 \
+        astroid==1.6.5 \
+        flask==1.0.2 \
+        werkzeug==0.14.1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+log_level = DEBUG

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ requests-mock
 pylint==1.9.3
 astroid==1.6.5
 flask==1.1.1
+subprocess32==3.5.4 ; python_version=='2.7'
 werkzeug==0.15.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# Dependencies of stbt_rig
+keyring
+pytest
+requests
+
+# Dependencies of the tests
+requests-mock
+pylint==1.9.3
+astroid==1.6.5
+flask==1.1.1
+werkzeug==0.15.5

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -650,7 +650,7 @@ class Result(object):
         response = self._portal._get(
             '/api/v2/results%s/stbt.log' % self.json['result_id'])
         response.raise_for_status()
-        stream.write(response.content)
+        stream.write(response.text)
 
     def is_ok(self):
         return self.json['result'] == "pass"
@@ -723,13 +723,13 @@ class TestJob(object):
         r = self.portal._get(
             '/api/v2/results.xml', params={'filter': 'job:%s' % self.job_uid})
         r.raise_for_status()
-        return r.content
+        return r.text
 
     def list_results_csv(self):
         r = self.portal._get(
             '/api/v2/results.csv', params={'filter': 'job:%s' % self.job_uid})
         r.raise_for_status()
-        return r.content
+        return r.text
 
     def get_status(self, timeout=60):
         if self._json.get('status') == 'exited':
@@ -784,7 +784,7 @@ class Node(object):
     def save_screenshot(self, filename):
         r = self._get("screenshot.png")
         r.raise_for_status()
-        with open(filename, 'w') as f:
+        with open(filename, 'wb') as f:
             f.write(r.content)
 
     def _get(self, suffix="", **kwargs):

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -882,19 +882,14 @@ class TestPack(object):
         self.root = root
         self.remote = remote
 
-    def _git(self, cmd, capture_output=True, extra_env=None, **kwargs):  # pylint:disable=no-self-use
-        if capture_output:
-            call = subprocess.check_output
-        else:
-            call = subprocess.check_call
-
+    def _git(self, cmd, extra_env=None, **kwargs):  # pylint:disable=no-self-use
         env = kwargs.get('env', os.environ).copy()
         if extra_env:
             env.update(extra_env)
 
         logger.debug('+git %s', " ".join(cmd))
 
-        return call(["git"] + cmd, env=env, **kwargs)
+        return subprocess.check_output(["git"] + cmd, env=env, **kwargs)
 
     def get_sha(self, branch='HEAD', obj_type=None):
         if obj_type:

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1170,18 +1170,13 @@ def to_unicode(text):
 # Python 2 & 3 compatible way of raising an exception with traceback.
 # Copied from python-future so that we don't have to add a dependency.
 if sys.version_info.major == 3:
-    def raise_(tp, value=None, tb=None):
+    def raise_(tp, value, tb):  # pylint:disable=unused-argument
         """
         A function that matches the Python 2.x ``raise`` statement. This
         allows re-raising exceptions with the cls value and traceback on
         Python 2 and 3.
         """
-        if value is not None and isinstance(tp, Exception):
-            raise TypeError("instance exception may not have a separate value")
-        if value is not None:
-            exc = tp(value)
-        else:
-            exc = tp
+        exc = value
         if exc.__traceback__ is not tb:
             raise exc.with_traceback(tb)
         raise exc

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -156,8 +156,8 @@ def _list_node_ids(**_kwargs):
     """
 
     return [f[17:-5]
-            for f in subprocess.check_output(
-                ["git", "ls-files", "config/test-farm/stb-tester-*.conf"])
+            for f in to_unicode(subprocess.check_output(
+                ["git", "ls-files", "config/test-farm/stb-tester-*.conf"]))
             .strip().split("\n")]
 
 
@@ -177,8 +177,8 @@ def _list_test_cases(prefix, **_kwargs):
     else:
         # List files:
         return [f + "::"
-                for f in subprocess.check_output(
-                    ["git", "ls-files", "tests/**.py"]).strip().split("\n")]
+                for f in to_unicode(subprocess.check_output(
+                    ["git", "ls-files", "tests/**.py"])).strip().split("\n")]
 
 
 ARGPARSE_EPILOGUE = dedent("""\
@@ -889,7 +889,8 @@ class TestPack(object):
 
         logger.debug('+git %s', " ".join(cmd))
 
-        return subprocess.check_output(["git"] + cmd, env=env, **kwargs)
+        return to_unicode(
+            subprocess.check_output(["git"] + cmd, env=env, **kwargs))
 
     def get_sha(self, branch='HEAD', obj_type=None):
         if obj_type:
@@ -1150,6 +1151,20 @@ def named_temporary_directory(suffix='', prefix='tmp', dir=None,
 def die(message, *args):
     logger.error(message, *args)
     sys.exit(1)
+
+
+def to_bytes(text):
+    if isinstance(text, bytes):
+        return text
+    else:
+        return text.encode("utf-8", errors="backslashreplace")
+
+
+def to_unicode(text):
+    if isinstance(text, bytes):
+        return text.decode("utf-8", errors="replace")
+    else:
+        return text
 
 
 # Python 2 & 3 compatible way of raising an exception with traceback.

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -887,6 +887,10 @@ class TestPack(object):
         if extra_env:
             env.update(extra_env)
 
+        # On Windows environment variables must be bytes on 2.7 and unicode on
+        # 3.0+
+        env = {to_native_str(k): to_native_str(v) for k, v in env.items()}
+
         logger.debug('+git %s', " ".join(cmd))
 
         return to_unicode(
@@ -1165,6 +1169,13 @@ def to_unicode(text):
         return text.decode("utf-8", errors="replace")
     else:
         return text
+
+
+def to_native_str(text):
+    if sys.version_info.major == 2:
+        return to_bytes(text)
+    else:
+        return to_unicode(text)
 
 
 # Python 2 & 3 compatible way of raising an exception with traceback.

--- a/test_retry_session.py
+++ b/test_retry_session.py
@@ -1,3 +1,6 @@
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals)
+
 import logging
 from collections import namedtuple
 from contextlib import contextmanager

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -15,6 +15,7 @@ import pytest
 import requests
 
 import stbt_rig
+from stbt_rig import to_unicode
 
 
 @pytest.fixture(scope="function", name="tmpdir")
@@ -71,13 +72,13 @@ def assert_status_unmodified():
 
 
 def cat(revision, filename):
-    return subprocess.check_output(
-        ['git', 'cat-file', 'blob', "%s:%s" % (revision, filename)])
+    return to_unicode(subprocess.check_output(
+        ['git', 'cat-file', 'blob', "%s:%s" % (revision, filename)]))
 
 
 def rev_parse(revision):
-    return subprocess.check_output(
-        ['git', 'rev-parse', '--verify', revision]).strip()
+    return to_unicode(subprocess.check_output(
+        ['git', 'rev-parse', '--verify', revision])).strip()
 
 
 def test_testpack_snapshot_contains_modifications(test_pack):

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -1,5 +1,4 @@
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import logging
 import os
@@ -16,7 +15,7 @@ import pytest
 import requests
 
 import stbt_rig
-from stbt_rig import to_unicode
+from stbt_rig import to_native_str, to_unicode
 
 
 @pytest.fixture(scope="function", name="tmpdir")
@@ -270,7 +269,7 @@ def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
 
 def test_run_tests_jenkins(tmpdir, portal_mock):
     env = os.environ.copy()
-    env["JENKINS_HOME"] = tmpdir
+    env["JENKINS_HOME"] = to_native_str(tmpdir)
     env["STBT_AUTH_TOKEN"] = "this is my token"
     env["BUILD_ID"] = "1"
     env["BUILD_URL"] = "https://jenkins/job/test/1"
@@ -280,7 +279,7 @@ def test_run_tests_jenkins(tmpdir, portal_mock):
 
 def test_run_tests_bamboo(tmpdir, portal_mock):
     env = os.environ.copy()
-    env["bamboo_agentWorkingDirectory"] = tmpdir
+    env["bamboo_agentWorkingDirectory"] = to_native_str(tmpdir)
     env["bamboo_STBT_AUTH_PASSWORD"] = "this is my token"
     env["bamboo_shortJobName"] = "test"
     env["bamboo_buildPlanName"] = "test"

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -255,7 +255,7 @@ def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
     env = os.environ.copy()
     env['PYTHONPATH'] = os.path.dirname(os.path.abspath(__file__))
     subprocess.check_call([
-        python, '-m', 'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
+        python, '-m', 'pytest', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
         '--portal-url=%s' % portal_mock.url, '--portal-auth-file=token',
         '--node-id=mynode', 'tests/test.py::test_my_tests'], env=env)
 
@@ -263,7 +263,7 @@ def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
     portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
                                  node_id="mynode")
     subprocess.check_call([
-        python, '-m', 'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
+        python, '-m', 'pytest', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
         '--portal-url=%s' % portal_mock.url, '--portal-auth-file=../token',
         '--node-id=mynode', 'test.py::test_my_tests'], env=env)
 

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -1,3 +1,6 @@
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals)
+
 import logging
 import os
 import re

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -6,7 +6,6 @@ import re
 import socket
 import threading
 import time
-import subprocess
 from contextlib import contextmanager
 from sys import executable as python
 from textwrap import dedent
@@ -16,6 +15,12 @@ import requests
 
 import stbt_rig
 from stbt_rig import to_native_str, to_unicode
+
+try:
+    # Needed for timeout argument to wait on Python 2.7
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
 
 
 @pytest.fixture(scope="function", name="tmpdir")
@@ -294,5 +299,5 @@ def run_tests_ci(portal_mock, env):
         [python, stbt_rig.__file__, "--node-id=mynode",
          "--portal-url", portal_mock.url,
          "run", "tests/test.py::test_my_tests"],
-        env=env)
+        env=env, timeout=10)
     assert open("stbt-results.xml").read() == PortalMock.RESULTS_XML

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -9,6 +9,7 @@ import threading
 import time
 import subprocess
 from contextlib import contextmanager
+from sys import executable as python
 from textwrap import dedent
 
 import pytest
@@ -254,7 +255,7 @@ def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
     env = os.environ.copy()
     env['PYTHONPATH'] = os.path.dirname(os.path.abspath(__file__))
     subprocess.check_call([
-        'python', '-m', 'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
+        python, '-m', 'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
         '--portal-url=%s' % portal_mock.url, '--portal-auth-file=token',
         '--node-id=mynode', 'tests/test.py::test_my_tests'], env=env)
 
@@ -262,7 +263,7 @@ def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
     portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
                                  node_id="mynode")
     subprocess.check_call([
-        'python', '-m', 'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
+        python, '-m', 'py.test', '-vv', '-p', 'stbt_rig', '-p', 'no:python',
         '--portal-url=%s' % portal_mock.url, '--portal-auth-file=../token',
         '--node-id=mynode', 'test.py::test_my_tests'], env=env)
 
@@ -291,7 +292,7 @@ def run_tests_ci(portal_mock, env):
     portal_mock.expect_run_tests(test_cases=["tests/test.py::test_my_tests"],
                                  node_id="mynode")
     subprocess.check_call(
-        ["python", stbt_rig.__file__, "--node-id=mynode",
+        [python, stbt_rig.__file__, "--node-id=mynode",
          "--portal-url", portal_mock.url,
          "run", "tests/test.py::test_my_tests"],
         env=env)


### PR DESCRIPTION
- [x] Fix `os.environ` keys and/or values can't be unicode on Python 2 on Windows.
- [x] Use requirements.txt in docker scripts too