### PR TITLE
Fix find_test_pack_root on Windows

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -595,7 +595,13 @@ def iter_portal_auth_tokens(portal_url, portal_auth_file, mode):
     while True:
         sys.stderr.write('Enter Access Token for portal %s: ' % portal_url)
         sys.stderr.flush()
-        token = sys.stdin.readline().strip()
+        token = sys.stdin.readline()
+        if not token:
+            # EOF
+            sys.stderr.write("EOF!\n")
+            sys.stderr.flush()
+            break
+        token = token.strip()
         if token:
             if keyring is not None:
                 keyring.set_password(portal_url, "", token)
@@ -1144,6 +1150,8 @@ try:
                         message += " during %s %s" % (
                             e.request.method, e.request.url)  # pylint:disable=no-member
                     die(message)
+        else:
+            die("Unauthorised")
 
         capmanager.resume_global_capture()
 

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -542,7 +542,12 @@ def find_test_pack_root():
     containing .stbt.conf
     """
     root = os.getcwd()
-    while root != '/':
+
+    # This gets the toplevel in a cross-platform manner "/" on UNIX and
+    # (typically) "c:\" on Windows:
+    toplevel = os.path.abspath(os.sep)
+
+    while root != toplevel:
         if os.path.exists(os.path.join(root, '.stbt.conf')):
             return root
         root = os.path.split(root)[0]

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -594,6 +594,7 @@ def iter_portal_auth_tokens(portal_url, portal_auth_file, mode):
 
     while True:
         sys.stderr.write('Enter Access Token for portal %s: ' % portal_url)
+        sys.stderr.flush()
         token = sys.stdin.readline().strip()
         if token:
             if keyring is not None:
@@ -921,6 +922,7 @@ class TestPack(object):
             sys.stderr.write(
                 '\nTo avoid this warning add untracked files (with "git add") '
                 'or add them to .gitignore\n')
+            sys.stderr.flush()
 
         base_commit = self.get_sha(obj_type="commit")
 
@@ -1093,6 +1095,7 @@ try:
                     message += " during %s %s" % (
                         e.request.method, e.request.url)  # pylint:disable=no-member
                 sys.stderr.write(message + '\n')
+                sys.stderr.flush()
                 raise
             finally:
                 self.session.stbt_args.test_cases = None


### PR DESCRIPTION
`find_test_pack_root` has an infinite loop on Windows when `stbt_rig.py` is run outside of a test-pack repository (for example, on a Jenkins CI job where you'd be running it from the checkout of the device-under-test's code, not a checkout of the test-pack).

This fixes our 2 failing tests on Windows: `test_run_tests_jenkins` and `test_run_tests_bamboo`.