### PR TITLE
Auth: Use a requests adapter rather than an outer loop for retries

### DIFF
--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -175,7 +175,7 @@ class PortalMock(object):
                 response = flask.make_response("Unauthorized", 401,
                     {'WWW-Authenticate':'Basic realm="Login Required"'})
                 return response
-            if (flask.request.headers['Authorization'] !=
+            if (flask.request.headers.get('Authorization') !=
                     "token this is my token"):
                 return ("Forbidden", 403)
             else:


### PR DESCRIPTION
I think this is a much neater design.  The retry loop happens at a single
request level rather than retrying the whole operation on auth failure.
It will also only apply to http requests to the portal, although we don't
currently have any other type.

It should make stbt_rig more convenient to use as a library too.

TODO:

- [x] Do some manual testing of auth scenarios too