### PR TITLE
Use refs/snapshots/$username instead of refs/heads/$username/snapshot

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1066,7 +1066,8 @@ class TestPack(object):
         options = ['--force']
         if not logger.isEnabledFor(logging.DEBUG):
             options.append('--quiet')
-        logger.info("Pushing git snapshot to %s:%s", self.remote, branch)
+        logger.info("Pushing git snapshot %s to %s:%s",
+                    commit_sha[:7], self.remote, branch)
         self._git(
             ['push'] + options +
             [self.remote,

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1054,15 +1054,47 @@ class TestPack(object):
                 ['write-tree'],
                 extra_env={'GIT_INDEX_FILE': tmp_index}).strip()
 
-        if self.get_sha(obj_type="tree") == write_tree:
-            return base_commit
+        head = self._git(["rev-parse", "--symbolic-full-name", "HEAD"]).strip()
+        remoteref = self._git(
+            ["for-each-ref",
+             "--format=%(push:remoteref)\n%(upstream:remoteref)\n",
+             head]).split('\n')
+        if remoteref and remoteref[0]:
+            # push:remoteref set if the repo is configured to push to a
+            # different place from which it fetches
+            remoteref = remoteref[0]
+        elif len(remoteref) > 1 and remoteref[1]:
+            # upstream:remoteref will be set otherwise, assuming we've actually
+            # got a remote tracking branch.
+            remoteref = remoteref[1]
         else:
-            return self._git(
-                ['commit-tree', write_tree, '-p', base_commit, '-m',
-                 "snapshot"]).strip()
+            remoteref = ""
+
+        no_workingdir_changes = (self.get_sha(obj_type="tree") == write_tree)
+        if no_workingdir_changes:
+            # No changes, we still want a new commit so we can inform the portal
+            # which branch we're working on.  We copy over the author date and
+            # committer date so we'll get the same SHA every time.  This will
+            # cut down on push time and object pollution.
+            ad, cd = self._git(
+                ["show", base_commit, "--no-patch",
+                 "--format=%ad\n%cd"]).split('\n')[:2]
+            extra_env = {"GIT_AUTHOR_DATE": ad, "GIT_COMMITTER_DATE": cd}
+        else:
+            extra_env = {}
+
+        commit_sha = self._git(
+            ['commit-tree', write_tree, '-p', base_commit, '-m',
+             "snapshot\n\nremoteref: %s" % remoteref],
+            extra_env=extra_env).strip()
+
+        if no_workingdir_changes:
+            return commit_sha, base_commit
+        else:
+            return commit_sha, commit_sha
 
     def push_git_snapshot(self, branch, interactive=True):
-        commit_sha = self.take_snapshot()
+        commit_sha, run_sha = self.take_snapshot()
         options = ['--force']
         if not logger.isEnabledFor(logging.DEBUG):
             options.append('--quiet')
@@ -1073,7 +1105,7 @@ class TestPack(object):
             [self.remote,
              '%s:%s' % (commit_sha, branch)],
             interactive=interactive)
-        return commit_sha
+        return run_sha
 
 
 class RetrySession(object):

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -31,7 +31,8 @@ def fixture_tmpdir():
     with stbt_rig.named_temporary_directory(ignore_errors=True) as d:
         origdir = os.path.abspath(os.curdir)
         try:
-            os.chdir(d)
+            os.mkdir("%s/test-pack" % d)
+            os.chdir("%s/test-pack" % d)
             yield d
         finally:
             os.chdir(origdir)
@@ -39,13 +40,13 @@ def fixture_tmpdir():
 
 @pytest.fixture(scope="function", name="test_pack")
 def fixture_test_pack(tmpdir):  # pylint: disable=unused-argument
-    subprocess.check_call(['git', 'init'])
+    os.mkdir("../upstream")
+    subprocess.check_call(['git', 'init', '--bare'], cwd="../upstream")
+
+    subprocess.check_call(['git', 'clone', '../upstream', '.'])
     subprocess.check_call([
         'git', 'config', 'user.email', 'stbt-rig@stb-tester.com'])
     subprocess.check_call(['git', 'config', 'user.name', 'stbt-rig tests'])
-
-    # Make git push a noop
-    subprocess.check_call(['git', 'remote', 'add', 'origin', '.'])
 
     with open(".stbt.conf", "w") as f:
         f.write(dedent("""\
@@ -62,13 +63,24 @@ def fixture_test_pack(tmpdir):  # pylint: disable=unused-argument
     subprocess.check_call(
         ['git', 'add', '.stbt.conf', 'moo', '.gitignore', 'tests/test.py'])
     subprocess.check_call(['git', 'commit', '-m', 'Test'])
+    subprocess.check_call(['git', 'push', '-u', 'origin', 'master:mybranch'])
 
     return stbt_rig.TestPack()
 
 
 def test_testpack_snapshot_no_change_if_no_commits(test_pack):
     with assert_status_unmodified():
-        assert rev_parse("HEAD") == test_pack.take_snapshot()
+        commit_sha, run_sha = test_pack.take_snapshot()
+        assert rev_parse("HEAD") == run_sha
+        assert tree_sha(commit_sha) == tree_sha(run_sha)
+        assert commit_msg(commit_sha) == (
+            "snapshot\n\nremoteref: refs/heads/mybranch")
+
+        # Check that the SHA is deterministic:
+        time.sleep(1)
+        new_commit_sha, new_run_sha = test_pack.take_snapshot()
+        assert new_commit_sha == commit_sha
+        assert new_run_sha == run_sha
 
 
 @contextmanager
@@ -89,15 +101,26 @@ def rev_parse(revision):
         ['git', 'rev-parse', '--verify', revision])).strip()
 
 
+def tree_sha(revision):
+    return to_unicode(subprocess.check_output(
+        ['git', 'show', '--format=%T', '--no-patch', revision])).strip()
+
+
+def commit_msg(revision):
+    return to_unicode(subprocess.check_output(
+        ['git', 'show', '--format=%s\n\n%b', '--no-patch', revision])).strip()
+
+
 def test_testpack_snapshot_contains_modifications(test_pack):
     with open("moo", "w") as f:
         f.write("Goodbye!\n")
 
     with assert_status_unmodified():
-        ss = test_pack.take_snapshot()
-        assert ss != rev_parse("HEAD")
-        assert rev_parse("%s~1" % ss) == rev_parse("HEAD")
-        assert cat(ss, 'moo') == "Goodbye!\n"
+        cs, rs = test_pack.take_snapshot()
+        assert cs == rs
+        assert rs != rev_parse("HEAD")
+        assert rev_parse("%s~1" % rs) == rev_parse("HEAD")
+        assert cat(rs, 'moo') == "Goodbye!\n"
         assert cat("HEAD", 'moo') == "Hello!\n"
 
 
@@ -108,9 +131,10 @@ def test_testpack_snapshot_with_untracked_files(test_pack, capsys):
 
     with assert_status_unmodified():
         orig_sha = rev_parse("HEAD")
-        ss = test_pack.take_snapshot()
+        cs, rs = test_pack.take_snapshot()
         # Untracked files aren't included in the snapshot:
-        assert orig_sha == ss
+        assert orig_sha == rs
+        assert tree_sha(cs) == tree_sha(orig_sha)
 
     assert capsys.readouterr() == ("", dedent("""\
         stbt-rig: Warning: Ignoring untracked files:

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
 import glob
-import logging
 import os
 import platform
 import random
 import re
-import socket
 import threading
 import time
 from contextlib import contextmanager


### PR DESCRIPTION
This way the snapshot ref isn't a normal branch (because it's in
`refs/snapshot` not `refs/heads`) which used to confuse some users (e.g.
you could create a pull request from the snapshot branch, but on your
next save it'd overwrite the contents of that branch without preserving
any history of the previous snapshots).

Note: We need to call `portal.notify_push` because github only notifies
for normal branches in `refs/heads`. We only need to call
`portal.notify_push` from the explicit snapshot command; when we call
`push_git_snapshot` from `run_tests`, we immediately follow up by
telling the portal to run the tests, and we tell the portal what the new
SHA is so the portal will do a `git fetch` if it doesn't have the SHA.

TODO:

- [x] Rename to refs/snapshot**s**
- [x] deploy to all portals before merging this.