### PR TITLE
Add --junit-xml option

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -342,6 +342,10 @@ RUN_ARGS = [
         {result_id}/artifacts/{filename}.  Directories will be created as
         required."""),
 
+    Arg("--junit-xml", action="append", dest="junit_xml", default=[],
+        help="""Save JUnit style XML file with results to this path.  This is
+        enabled by default in jenkins or bamboo mode.""", cmdline_only=True),
+
     Arg("test_cases", nargs='+', metavar="TESTCASE",
         help="""One or more tests to run. Test names have the form
         FILENAME::FUNCTION_NAME where FILENAME is given relative to the root of
@@ -509,9 +513,14 @@ def cmd_run_body(args, node, j):
             result.print_logs()
     elif args.mode in ["bamboo", "jenkins"]:
         # Record results in XML format for the Jenkins JUnit plugin
+        if not args.junit_xml:
+            args.junit_xml = ["stbt-results.xml"]
+
+    if args.junit_xml:
         results_xml = job.list_results_xml()
-        with open("stbt-results.xml", "w") as f:
-            f.write(results_xml)
+        for filename in args.junit_xml:
+            with open(filename, "w") as f:
+                f.write(results_xml)
 
     if args.csv:
         results_csv = job.list_results_csv()

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -320,6 +320,20 @@ def test_run_tests_download_artifacts(test_pack, tmpdir, portal_mock):
         'tests/test.py::test_my_tests'])
 
 
+def test_run_tests_junit_xml(test_pack, tmpdir, portal_mock):
+    with open('token', 'w') as f:
+        f.write("this is my token")
+    portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
+                                 node_id="mynode")
+
+    assert 0 == stbt_rig.main([
+        'stbt_rig.py', '--node-id=mynode', '--portal-url=%s' % portal_mock.url,
+        '--portal-auth-file=token', 'run',
+        '--junit-xml=results.xml',
+        'tests/test.py::test_my_tests'])
+    assert open("results.xml").read() == PortalMock.RESULTS_XML
+
+
 def test_run_tests_pytest(test_pack, tmpdir, portal_mock):
     with open('token', 'w') as f:
         f.write("this is my token")


### PR DESCRIPTION
So users can save this xml even if they're running in interactive mode.
This is useful for integration with external test-reporting systems.