### PR TITLE
Add "download" command to download artifacts from a previous test-result

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -262,16 +262,16 @@ RUN_ARGS = [
         specified more than once."""),
 
     Arg(("--artifacts"), action="append", dest="artifacts", default=[],
-        metavar="GLOB", help="""Select artifacts to be downloaded.  This is a
-        filename glob.  Set to `*` for all artifacts.  This argument can be
+        metavar="GLOB", help="""Download the specified artifacts. This is a
+        filename glob. Set to "*" for all artifacts. This argument can be
         specified multiple times."""),
 
     Arg(("--artifacts-dest"), metavar="PATH",
         default=os.path.join("{result_id}", "artifacts", "{filename}"),
-        help="""Artifacts will be downloaded to here. You can include the
-        placeholders {result_id}, {filename} and {basename} here to be filled
-        in automatically by stbt_rig. Defaults to "%(default)s". Directories
-        will be created as required."""),
+        help="""Download the artifacts (specified by --artifacts) to PATH. You
+        can use the placeholders {result_id}, {filename} and {basename}.
+        Defaults to "%(default)s". Directories will be created as
+        required."""),
 
     Arg("--junit-xml", action="append", dest="junit_xml", default=[],
         help="""Save JUnit style XML file with results to this path.  This is
@@ -319,16 +319,15 @@ def argparser():
         the specified test-result.""")
     download_parser.add_argument(
         "--artifacts", action="append", dest="artifacts", default=[],
-        metavar="GLOB", help="""Select artifacts to be downloaded.  This is a
-        filename glob.  Defaults to `*` (all artifacts).  This argument can be
+        metavar="GLOB", help="""Download the specified artifacts. This is a
+        filename glob. Defaults to "*" (all artifacts). This argument can be
         specified multiple times.""")
     download_parser.add_argument(
         "--artifacts-dest", metavar="PATH",
         default=os.path.join("{result_id}", "artifacts", "{filename}"),
-        help="""Artifacts will be downloaded to here. You can include the
-        placeholders {result_id}, {filename} and {basename} here to be filled
-        in automatically by stbt_rig. Defaults to "%(default)s". Directories
-        will be created as required.""")
+        help="""Download the artifacts (specified by --artifacts) to PATH. You
+        can use the placeholders {result_id}, {filename} and {basename}.
+        Defaults to "%(default)s". Directories will be created as required.""")
     download_parser.add_argument(
         "result_id", help='''Identifier that refers to a test result, as
         returned from Stb-tester's REST API for running a test

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -264,12 +264,12 @@ RUN_ARGS = [
         filename glob.  Set to `*` for all artifacts.  This argument can be
         specified multiple times."""),
 
-    Arg(("--artifacts-dest"), default=None, metavar="PATH", help="""Artifacts
-        will be downloaded to here.  You can include the placeholders
-        {result_id}, {filename} and {basename} here to be filled in
-        automatically by stbt_rig.  Defaults to
-        {result_id}/artifacts/{filename}.  Directories will be created as
-        required."""),
+    Arg(("--artifacts-dest"), metavar="PATH",
+        default=os.path.join("{result_id}", "artifacts", "{filename}"),
+        help="""Artifacts will be downloaded to here. You can include the
+        placeholders {result_id}, {filename} and {basename} here to be filled
+        in automatically by stbt_rig. Defaults to "%(default)s". Directories
+        will be created as required."""),
 
     Arg("--junit-xml", action="append", dest="junit_xml", default=[],
         help="""Save JUnit style XML file with results to this path.  This is
@@ -687,12 +687,7 @@ class Result(object):
             self.json = r.json()
         return self.json["artifacts"]
 
-    def download_artifacts(self, patterns=("*",), out_pattern=None):
-        if out_pattern is None:
-            if platform.system() == "Windows":
-                out_pattern = "{result_id}\\artifacts\\{filename}"
-            else:
-                out_pattern = "{result_id}/artifacts/{filename}"
+    def download_artifacts(self, patterns, out_pattern):
         for filename, info in self.list_artifacts().items():
             for p in patterns:
                 if fnmatch.fnmatch(filename, p):

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -756,12 +756,12 @@ class Result(object):
         # This way we can avoid downloading the same file twice if we've already
         # downloaded it:
         if info and _file_is_same(outname, info['size'], info['md5']):
-            logger.debug("Not Downloading %s/artifacts/%s to %s - file is "
-                         "unmodified", self.result_id, artifact, outname)
+            logger.info("Not Downloading %s/artifacts/%s to %s - file is "
+                        "unmodified", self.result_id, artifact, outname)
             return
 
-        logger.debug("Downloading %s/artifacts/%s to %s",
-                     self.result_id, artifact, outname)
+        logger.info("Downloading %s/artifacts/%s to %s",
+                    self.result_id, artifact, outname)
         resp = self._portal._get(
             "/api/v2/results%s/artifacts/%s" % (self.result_id, artifact),
             stream=True)


### PR DESCRIPTION
TODO:

- [x] Fix `stbt_rig.py download --help` output to show different default value for `--artifacts` (it defaults to `[*]` for all artifacts, vs. `[]` for no artifacts for the `run` command).
- [x] Rebase onto master.
- [x] Make it take a filter instead of a single result id.
- [x] Update manual: https://stb-tester.com/manual/stbt-rig