### PR TITLE
JUnit XML output: Include timezone information in XML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,9 @@ requests
 
 # Dependencies of the tests
 requests-mock
-pylint==1.9.3
-astroid==1.6.5
+pylint==1.8.3
+astroid==1.6.0
 flask==1.1.1
+isort==4.3.4
 subprocess32==3.5.4 ; python_version=='2.7'
 werkzeug==0.15.5

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1235,6 +1235,7 @@ try:
 
 
     class StbtCollector(pytest.File):
+        # pylint: disable=abstract-method
         def collect(self):
             with open(self.fspath.strpath) as f:
                 # We implement our own parsing to avoid import stbt ImportErrors
@@ -1255,6 +1256,7 @@ try:
 
 
     class StbtRemoteTest(pytest.Item):
+        # pylint: disable=abstract-method
         def __init__(self, parent, filename, testname, line_number):
             super(StbtRemoteTest, self).__init__(testname, parent)
             self._filename = filename

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -6,7 +6,7 @@
 For more details, and to get the latest version of this script, see
 <https://github.com/stb-tester/stbt-rig>.
 
-Copyright 2017-2019 Stb-tester.com Ltd. <support@stb-tester.com>
+Copyright 2017-2020 Stb-tester.com Ltd. <support@stb-tester.com>
 Released under the MIT license.
 """
 

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -839,7 +839,8 @@ class TestJob(object):
 
     def list_results_xml(self):
         r = self.portal._get(
-            '/api/v2/results.xml', params={'filter': 'job:%s' % self.job_uid})
+            '/api/v2/results.xml', params={'filter': 'job:%s' % self.job_uid,
+                                           'include_tz': 'true'})
         r.raise_for_status()
         return r.text
 

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -208,6 +208,7 @@ class PortalMock(object):
         @self.app.route('/api/v2/results.xml')
         def get_results_xml():
             assert flask.request.args['filter'] == 'job:/mynode/6Pfq/167'
+            assert flask.request.args['include_tz'] == 'true'
             return PortalMock.RESULTS_XML
 
         @self.app.route('/api/v2/results/<path:result_id>')
@@ -276,7 +277,7 @@ class PortalMock(object):
     RESULTS_XML = (
         '<testsuite disabled="0" errors="0" failures="0" '
         'name="test" skipped="0" tests="1" time="3.270815" '
-        'timestamp="2019-06-12T15:26:35">'
+        'timestamp="2019-06-12T15:26:35+00:00">'
         '<testcase classname="tests/test.py" name="test_my_tests" '
         'time="3.270815"/>'
         '</testsuite>')


### PR DESCRIPTION
JUnit writes local-time without a timezone by default.  This means that
JUnit XML parsers default to local-time.  The portal doesn't know what
timezone the user of stbt-rig wants so these timestamps can be interpreted
incorrectly.  This change includes timezone information in the XML output.

There is a small chance of incompatibility caused by this change.  If you
experience this please get in contact at support@stb-tester.com.

TODO:

- [x] Test against real portal
- [x] Test with real Jenkins