### PR TITLE
Display test's log in user's local timezone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+check:
+	pylint stbt_rig.py
+	pylint3 stbt_rig.py
+	pytest -vv -rs
+	pytest-3 -vv -rs

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 keyring
 pytest
 requests
+tzlocal
 
 # Dependencies of the tests
 requests-mock

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -789,16 +789,17 @@ def _get_local_timezone():
         return str(tzlocal.get_localzone())
     except ImportError:
         pass
-    try:
-        # On Unix systems /etc/localtime is a symlink. On Ubuntu it points to
-        # "/usr/share/zoneinfo/Europe/London". On MacOS it points to
-        # "/var/db/timezone/zoneinfo/Europe/London".
-        zoneinfo_filename = os.readlink("/etc/localtime")
-        m = re.match(r"^.*/zoneinfo/(.*)", zoneinfo_filename)
-        if m:
-            return m.group(1)
-    except OSError:
-        pass
+    if platform.system() != "Windows":
+        try:
+            # On Unix systems /etc/localtime is a symlink. On Ubuntu it points
+            # to "/usr/share/zoneinfo/Europe/London". On MacOS it points to
+            # "/var/db/timezone/zoneinfo/Europe/London".
+            zoneinfo_filename = os.readlink("/etc/localtime")  # pylint:disable=no-member
+            m = re.match(r"^.*/zoneinfo/(.*)", zoneinfo_filename)
+            if m:
+                return m.group(1)
+        except OSError:
+            pass
     return None
 
 

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -688,8 +688,14 @@ class Result(object):
     def print_logs(self, stream=None):
         if stream is None:
             stream = sys.stdout
+        tz = _get_local_timezone()
+        if tz:
+            params = {"tz": tz}
+        else:
+            params = {}
         response = self._portal._get(
-            '/api/v2/results%s/stbt.log' % self.result_id)
+            '/api/v2/results%s/stbt.log' % self.result_id,
+            params=params)
         response.raise_for_status()
         stream.write(response.text)
 
@@ -775,6 +781,25 @@ class Result(object):
             raise TestError(self.json['traceback'])
         elif self.json['result'] == 'fail':
             raise TestFailure(self.json['traceback'])
+
+
+def _get_local_timezone():
+    try:
+        import tzlocal
+        return str(tzlocal.get_localzone())
+    except ImportError:
+        pass
+    try:
+        # On Unix systems /etc/localtime is a symlink. On Ubuntu it points to
+        # "/usr/share/zoneinfo/Europe/London". On MacOS it points to
+        # "/var/db/timezone/zoneinfo/Europe/London".
+        zoneinfo_filename = os.readlink("/etc/localtime")
+        m = re.match(r"^.*/zoneinfo/(.*)", zoneinfo_filename)
+        if m:
+            return m.group(1)
+    except OSError:
+        pass
+    return None
 
 
 def _file_is_same(filename, size, md5sum):


### PR DESCRIPTION
If [tzlocal] is installed (pip install tzlocal) we use that. If it's not installed, we try to work it out if running on Linux or MacOS. For Windows, tzlocal reads the timezone from the registry, and I'm not going to try to replicate that logic. Now that we have instructions for setting up a venv and installing stb-tester from PyPI, I think it's no longer too onerous to add additional dependencies. Nonetheless, tzlocal is still an optional dependency in this commit.

[tzlocal]: https://github.com/regebro/tzlocal