### PR TITLE
Package stbt_rig for PyPI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Stb-tester.com Ltd
+Copyright (c) 2017-2020 Stb-tester.com Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,8 @@ check:
 	pylint3 stbt_rig.py
 	pytest -vv -rs
 	pytest-3 -vv -rs
+
+pypi-publish:
+	rm -rf dist/
+	python3 setup.py sdist
+	twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+
+import setuptools
+
+
+setuptools.setup(
+    name="stbt_rig",
+    version="2.0.0",
+    author="Stb-tester.com Ltd.",
+    author_email="support@stb-tester.com",
+    description="Library for interacting with the Stb-tester Portal's REST API",
+    url="https://github.com/stb-tester/stbt-rig",
+    py_modules=["stbt_rig"],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Software Development :: Testing",
+    ],
+    # I have only tested Python 2.7 & 3.6
+    python_requires=">=2.7",
+    install_requires=[
+        "keyring",
+        "requests",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,26 @@
 import setuptools
 
 
+long_description = """\
+# stbt_rig
+
+Command-line tool & library for interacting with the Stb-tester Portal's [REST
+API].
+
+For more details see [IDE Configuration] in the Stb-tester manual.
+
+[IDE Configuration]: https://stb-tester.com/manual/ide-configuration
+[REST API]: https://stb-tester.com/manual/rest-api-v2
+"""
+
 setuptools.setup(
     name="stbt_rig",
-    version="2.0.0",
+    version="2.0.1",
     author="Stb-tester.com Ltd.",
     author_email="support@stb-tester.com",
     description="Library for interacting with the Stb-tester Portal's REST API",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/stb-tester/stbt-rig",
     py_modules=["stbt_rig"],
     classifiers=[


### PR DESCRIPTION
We use stbt_rig as a pytest plugin to run tests from inside VS Code,
like this: pytest -p stbt_rig (see #18). However VS Code doesn't execute
pytest directly; it executes pytest via a wrapper script. Recently this
wrapper script started removing the workspace root directory from
sys.path before invoking pytest, so pytest fails to import stbt_rig.
By installing stbt_rig into the standard python path inside your
project's venv, pytest will be able to find stbt_rig.