### PR TITLE
pytest mode: Don't push git snapshot during pytest collection

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1345,9 +1345,10 @@ try:
         resolve_args(session.stbt_args)
 
         pluginmanager = session.config.pluginmanager
-        if not session.config.option.collectonly:
-            pluginmanager.unregister(name="python")
+        if session.config.option.collectonly:
+            return
 
+        pluginmanager.unregister(name="python")
         capmanager = pluginmanager.getplugin('capturemanager')
         capmanager.suspend_global_capture(in_=True)
         for portal_auth_token in iter_portal_auth_tokens(
@@ -1377,6 +1378,7 @@ try:
 
         session.stbt_node = node
         session.stbt_run_prep = j
+
 except ImportError:
     # Pytest integration is optional
     pass


### PR DESCRIPTION
VS Code's "Discover Tests" command runs pytest with `--collect-only`.
This was taking a long time because we were pushing a git snapshot.

It would also fail intermittently due to a race with our "Run On Save"
configuration which also runs `stbt_rig snapshot`: The git push would
fail due to the upstream changing. This would cause VS Code's "Discover
Tests" to fail intermittently with an error message.