### PR TITLE
Add `setup` command to make initial setup a single step

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,10 +15,16 @@ jobs:
       matrix:
         environment: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        include:
+          - environment: ubuntu-latest
+            setup: dbus-run-session sh -c 'env $(echo password | gnome-keyring-daemon --unlock) "$0" "$@"'
 
     runs-on: ${{ matrix.environment }}
     steps:
     - uses: actions/checkout@v2
+    - name: Install gnome keyring
+      run: sudo apt-get install gnome-keyring
+      if: ${{ matrix.environment == 'ubuntu-latest' }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -26,4 +32,4 @@ jobs:
     - name: Install dependencies
       run: pip install -r requirements.txt
     - name: Test with pytest
-      run: pytest -vv
+      run: ${{ matrix.setup }} pytest -vv

--- a/conftest.py
+++ b/conftest.py
@@ -88,6 +88,8 @@ class PortalMock(object):
         self.socket = None
         self.address = None
 
+        self.nodes = ["stb-tester-00044b5af1d3", "stb-tester-00044b5aff8a"]
+
         RESULTS = [{
             "result": "pass",
             "triage_url": ("https://example.stb-tester.com/app/#/result/"
@@ -167,6 +169,10 @@ class PortalMock(object):
         @self.app.route('/api/v2/run_tests', methods=['POST'])
         def _post_run_tests():
             return flask.jsonify(self.on_run_tests(flask.request.json))
+
+        @self.app.route('/api/_private/workgroup')
+        def _get_private_workgroup():
+            return flask.jsonify([{"id": node} for node in self.nodes])
 
         @self.app.route("/shutdown", methods=['POST'])
         def _shutdown():

--- a/conftest.py
+++ b/conftest.py
@@ -233,6 +233,19 @@ def portal_mock():
         yield m
 
 
+def main():
+    import time
+
+    with PortalMock() as m, stbt_rig.named_temporary_directory(
+            prefix="stbt-rig-selftest-", ignore_errors=True) as tmpdir:
+        setup_test_pack(tmpdir, m.url)
+        print("Test pack at %s/test-pack\nListening on %s" % (tmpdir, m.url))
+        time.sleep(10000000)
+
+
 def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):
     return os.path.join(root, path)
 
+
+if __name__ == "__main__":
+    main()

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,82 @@
+import os
+import shutil
+from textwrap import dedent
+
+import pytest
+
+import stbt_rig
+
+try:
+    # Needed for timeout argument to wait on Python 2.7
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
+
+
+@pytest.fixture(scope="function", name="tmpdir")
+def fixture_tmpdir():
+    with stbt_rig.named_temporary_directory(
+            prefix="stbt-rig-selftest-", ignore_errors=True) as d:
+        origdir = os.path.abspath(os.curdir)
+        try:
+            yield d
+        finally:
+            os.chdir(origdir)
+
+
+@pytest.fixture(scope="function", name="test_pack")
+def fixture_test_pack(tmpdir):  # pylint: disable=unused-argument
+    setup_test_pack(tmpdir)
+    os.chdir("%s/test-pack" % tmpdir)
+    return stbt_rig.TestPack()
+
+
+def setup_test_pack(tmpdir, portal_url="https://example.stb-tester.com"):
+    u = os.path.join(tmpdir, "upstream")
+
+    def tp(path=""):
+        return os.path.join(tmpdir, "test-pack", path)
+
+    os.mkdir(u)
+    subprocess.check_call(['git', 'init', '--bare'], cwd=u)
+
+    subprocess.check_call(['git', 'clone', 'upstream', 'test-pack'], cwd=tmpdir)
+
+    subprocess.check_call(
+        ['git', 'config', 'user.email', 'stbt-rig@stb-tester.com'], cwd=tp())
+    subprocess.check_call(
+        ['git', 'config', 'user.name', 'stbt-rig tests'], cwd=tp())
+
+    with open(tp(".stbt.conf"), "w") as f:
+        f.write(dedent("""\
+            [test_pack]
+            stbt_version = 32
+            python_version = 3
+            portal_url = %s
+            """ % portal_url))
+    with open(tp(".gitignore"), "w") as f:
+        f.write("token\n__pycache__\n")
+    with open(tp("moo"), 'w') as f:
+        f.write("Hello!\n")
+    os.mkdir(tp("tests"))
+    with open(tp("tests/test.py"), 'w') as f:
+        f.write("def test_my_tests():\n    pass\n")
+    with open(tp("tests/syntax_error.py"), 'wb') as f:
+        f.write(
+            b'# codec: utf-8\n\n'
+            b'def test_its_a_test():\n\n'
+            b'syntax error\n\n'
+            b'I am \xf0\x9f\x98\x80')
+    shutil.copyfile(_find_file("stbt_rig.py"), tp("stbt_rig.py"))
+    os.chmod(tp("stbt_rig.py"), 0o0755)
+    subprocess.check_call(
+        ['git', 'add', '.stbt.conf', 'moo', '.gitignore', 'stbt_rig.py',
+         'tests/syntax_error.py', 'tests/test.py'], cwd=tp())
+    subprocess.check_call(['git', 'commit', '-m', 'Test'], cwd=tp())
+    subprocess.check_call(
+        ['git', 'push', '-u', 'origin', 'master:mybranch'], cwd=tp())
+
+
+def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):
+    return os.path.join(root, path)
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 import os
+import random
 import shutil
+import threading
 from textwrap import dedent
 
 import pytest
@@ -75,6 +77,154 @@ def setup_test_pack(tmpdir, portal_url="https://example.stb-tester.com"):
     subprocess.check_call(['git', 'commit', '-m', 'Test'], cwd=tp())
     subprocess.check_call(
         ['git', 'push', '-u', 'origin', 'master:mybranch'], cwd=tp())
+
+
+class PortalMock(object):
+    def __init__(self):
+        import flask
+        self.app = flask.Flask(__name__)
+        self.expectations = []
+        self.thread = None
+        self.socket = None
+        self.address = None
+
+        RESULTS = [{
+            "result": "pass",
+            "triage_url": ("https://example.stb-tester.com/app/#/result/"
+                           "/mynode/6Pfq/167/2018-10-10T13:13:20"),
+            "result_id": "/mynode/6Pfq/167/2018-10-10T13:13:20",
+            "artifacts": {
+                "combined.log": {
+                    "size": len(b'Downloaded \'combined.log\''),
+                    "md5": "a31802f438fa89d98d77796cadc5be14",
+                },
+                "screenshot.png": {
+                    "size": len(b'Downloaded \'screenshot.png\''),
+                    'md5': "4a2ae485dcf5cf9f391cb5ac65128385",
+                },
+            }
+        }]
+
+        @self.app.before_request
+        def _check_auth():
+            if flask.request.path.startswith('/unauthorised.git'):
+                # Used for testing git username prompt behaviour
+                response = flask.make_response("Unauthorized", 401,
+                    {'WWW-Authenticate':'Basic realm="Login Required"'})
+                return response
+            if (flask.request.headers.get('Authorization') !=
+                    "token this is my token"):
+                return ("Forbidden", 403)
+            else:
+                return None
+
+        @self.app.route("/ready")
+        def _ready():
+            return "Ready"
+
+        @self.app.route('/api/v2/user')
+        def _get_user():
+            return flask.jsonify({"login": "tester"})
+
+        @self.app.route('/api/v2/jobs/mynode/6Pfq/167')
+        def _get_job():
+            return flask.jsonify({'status': 'exited'})
+
+        @self.app.route('/api/v2/jobs/mynode/6Pfq/167/await_completion')
+        def _await_completion():
+            return "{}", random.choice([200, 202, 202, 202])
+
+        @self.app.route('/api/v2/results')
+        def _get_results():
+            assert flask.request.args['filter'] == 'job:/mynode/6Pfq/167'
+            out = [dict(x) for x in RESULTS]
+            for x in out:
+                del x['artifacts']
+            return flask.jsonify(out)
+
+        @self.app.route('/api/v2/results.xml')
+        def _get_results_xml():
+            assert flask.request.args['filter'] == 'job:/mynode/6Pfq/167'
+            assert flask.request.args['include_tz'] == 'true'
+            return PortalMock.RESULTS_XML
+
+        @self.app.route('/api/v2/results/<path:result_id>')
+        def _get_results_details(result_id):
+            return flask.jsonify([
+                x for x in RESULTS if x['result_id'] == '/' + result_id][0])
+
+        @self.app.route(
+                '/api/v2/results/mynode/6Pfq/167/2018-10-10T13:13:20/artifacts'
+                '/<path:path>')
+        def _get_artifact(path):
+            return "Downloaded %r" % path, 200
+
+        @self.app.route(
+            "/api/v2/results/mynode/6Pfq/167/2018-10-10T13:13:20/stbt.log")
+        def _get_stbt_log():
+            return "The log output\n"
+
+        @self.app.route('/api/v2/run_tests', methods=['POST'])
+        def _post_run_tests():
+            return flask.jsonify(self.on_run_tests(flask.request.json))
+
+        @self.app.route("/shutdown", methods=['POST'])
+        def _shutdown():
+            func = flask.request.environ.get('werkzeug.server.shutdown')
+            if func is None:
+                raise RuntimeError('Not running with the Werkzeug Server')
+            func()
+            return ""
+
+    def __enter__(self):
+        from werkzeug.serving import make_server
+        from werkzeug.debug import DebuggedApplication
+
+        server = make_server('localhost', 0, DebuggedApplication(self.app))
+        self.address = server.socket.getsockname()
+
+        self.thread = threading.Thread(target=server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+
+        return self
+
+    def __exit__(self, *_):
+        import requests
+        requests.post("%s/shutdown" % self.url,
+                      headers={'Authorization': "token this is my token"})
+        self.thread.join()
+        self.thread = None
+        self.socket = None
+
+        assert not self.expectations
+
+    @property
+    def url(self):
+        return "http://%s:%i" % self.address
+
+    def expect_run_tests(self, **kwargs):
+        self.expectations.append(kwargs)
+
+    def on_run_tests(self, j):
+        expected = self.expectations.pop(0)
+        for k, v in expected.items():
+            assert j[k] == v
+        return {'job_uid': '/mynode/6Pfq/167'}
+
+    RESULTS_XML = (
+        '<testsuite disabled="0" errors="0" failures="0" '
+        'name="test" skipped="0" tests="1" time="3.270815" '
+        'timestamp="2019-06-12T15:26:35+00:00">'
+        '<testcase classname="tests/test.py" name="test_my_tests" '
+        'time="3.270815"/>'
+        '</testsuite>')
+
+
+@pytest.fixture()
+def portal_mock():
+    with PortalMock() as m:
+        yield m
 
 
 def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ tzlocal
 
 # Dependencies of the tests
 requests-mock
+pexpect==4.8
 pylint==1.8.3
 astroid==1.6.0
 flask==1.1.1

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -562,6 +562,16 @@ def cmd_setup(args, node_id):
         portal = Portal.from_args(args)
         portal._get("/api/v2/user")
 
+        for k in "name", "email":
+            try:
+                subprocess.check_output(["git", "config", "user.%s" % k])
+            except subprocess.CalledProcessError as e:
+                if e.returncode == 1:
+                    v = ask("What is your %s (for git commits): " % k)
+                    subprocess.check_output(["git", "config", "user.%s" % k, v])
+                else:
+                    raise
+
         # Setup .env to include our node-id so we don't need to specify it every
         # time
         while not node_id:

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -514,11 +514,15 @@ def cmd_setup(args, node_id):
         stbt_version = int(config_parser.get("test_pack", "stbt_version"))
         python_version = config_parser.get("test_pack", "python_version")
 
+        if python_version != "3":
+            sys.stderr.write(
+                "Python version %r is not supported by stbt_rig.py setup.  "
+                "Please contact support@stb-tester.com\n" % (python_version,))
+            sys.exit(1)
+
         if not os.path.exists("%s/.venv" % root):
             python = None
-            for python in (["python"],
-                           ["python%s" % python_version],
-                           ["py", "-%s" % python_version]):
+            for python in (["python"], ["python3"], ["py", "-3"]):
                 try:
                     o = subprocess.check_output(
                         python + ["-c", "import sys; print(sys.version)"],

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -575,7 +575,7 @@ def cmd_setup(args, node_id):
         else:
             os.execv(cmd[0], cmd)
     else:
-        # Install ourselves as a python module in the venv:
+        # Install this stbt_rig as a python module in the venv:
         venv_site_packages = sys.path[-1]
         this_stbt_rig_rel = os.path.relpath(this_stbt_rig, venv_site_packages)
         pkg = os.path.join(venv_site_packages, "stbt_rig.py")
@@ -677,6 +677,7 @@ def _update_vscode_config():
             "--tb=no", "--capture=no",
             "tests"
         ],
+        # This requires the "pucelle.run-on-save" VSCode extension:
         "runOnSave.commands": [
             {
                 "match": ".*\\.py$",

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -553,6 +553,10 @@ def cmd_setup(args, node):
                     pass
                 os.symlink(this_stbt_rig_rel, pkg)  # pylint: disable=no-member
 
+        # This will prompt for the auth token and validate connectivity:
+        portal = Portal.from_args(args)
+        portal._get("/api/v2/user")
+
 
 def _get_snapshot_branch_name(portal):
     response = portal._get("/api/v2/user")

--- a/test-pack/.stbt.conf
+++ b/test-pack/.stbt.conf
@@ -1,4 +1,0 @@
-[test_pack]
-stbt_version = 32
-python_version = 3
-portal_url = https://demo.stb-tester.com

--- a/test-pack/tests/mytest.py
+++ b/test-pack/tests/mytest.py
@@ -1,7 +1,0 @@
-# codec: utf-8
-
-def test_its_a_test():
-
-syntax error
-
-I am 😀

--- a/test_setup.py
+++ b/test_setup.py
@@ -1,0 +1,74 @@
+import os
+import platform
+import sys
+
+from conftest import subprocess
+from conftest import setup_test_pack
+
+
+def test_setup(tmpdir, portal_mock):
+    if (3, 0) <= sys.version_info < (3, 6):
+        from unittest import SkipTest
+        raise SkipTest("%s not supported for setup" % sys.version)
+    if platform.system() == "Windows" and sys.version_info < (3, 6):
+        from unittest import SkipTest
+        raise SkipTest("%s not supported for setup" % sys.version)
+
+    import pexpect
+
+    setup_test_pack(tmpdir, portal_url=portal_mock.url)
+    test_pack = os.path.join(tmpdir, "test-pack")
+
+    # Undo any venv, we want a seperate venv for the tests and the stbt_rig
+    # we're testing
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    venv = env.pop("VIRTUAL_ENV", None)
+    if venv and venv in env['PATH']:
+        env['PATH'] = os.pathsep.join(
+            x for x in env["PATH"].split(os.pathsep) if venv not in x)
+
+    try:
+        # Python 3
+        stderr = sys.stderr.buffer
+    except AttributeError:
+        stderr = sys.stderr
+
+    try:
+        e = pexpect.spawn("python stbt_rig.py setup", cwd=test_pack,
+                          logfile=stderr)
+    except AttributeError:
+        # Windows:
+        from pexpect.popen_spawn import PopenSpawn
+        e = PopenSpawn(
+            "python stbt_rig.py setup", cwd=test_pack, logfile=stderr)
+    e.expect("Enter Access Token for portal %s:" % portal_mock.url,
+             timeout=300)
+    e.sendline("this is my token")
+
+    e.expect("These nodes are attached to the portal:")
+    e.expect("1\\) stb-tester-00044b5af1d3")
+    e.expect("2\\) stb-tester-00044b5aff8a")
+    e.expect("Which node do you want to use by default?")
+    e.sendline("2")
+    e.expect(pexpect.EOF, timeout=5)
+
+    # Setup is complete, now lets test that it worked
+    env["VIRTUAL_ENV"] = os.path.join(test_pack, ".venv")
+    if platform.system() == "Windows":
+        env["PATH"] = (
+            os.path.join(test_pack, ".venv", "Scripts") + ':' + env["PATH"])
+    else:
+        env["PATH"] = (
+            os.path.join(test_pack, ".venv", "bin") + ':' + env["PATH"])
+    with open(os.path.join(test_pack, ".env")) as f:
+        env.update(line.split("=", 1) for line in f.read().split('\n') if line)
+    portal_mock.expect_run_tests(test_cases=['tests/test.py::test_my_tests'],
+                                 node_id="stb-tester-00044b5aff8a")
+    subprocess.check_call(
+        ["python", "stbt_rig.py", "run", 'tests/test.py::test_my_tests'],
+        env=env, cwd=test_pack)
+
+
+def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):
+    return os.path.join(root, path)

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -3,20 +3,15 @@ from __future__ import absolute_import, division, print_function
 import glob
 import os
 import platform
-import random
 import re
-import threading
 import time
 from contextlib import contextmanager
 from sys import executable as python
 from textwrap import dedent
 
-import pytest
-import requests
-
 import stbt_rig
 from stbt_rig import to_native_str, to_unicode
-from conftest import subprocess
+from conftest import (subprocess, PortalMock)
 
 
 def test_testpack_snapshot_no_change_if_no_commits(test_pack):
@@ -94,152 +89,6 @@ def test_testpack_snapshot_with_untracked_files(test_pack, capsys):
 
         To avoid this warning add untracked files (with "git add") or add them to .gitignore
         """))
-
-
-class PortalMock(object):
-    def __init__(self):
-        import flask
-        self.app = flask.Flask(__name__)
-        self.expectations = []
-        self.thread = None
-        self.socket = None
-
-        RESULTS = [{
-            "result": "pass",
-            "triage_url": ("https://example.stb-tester.com/app/#/result/"
-                           "/mynode/6Pfq/167/2018-10-10T13:13:20"),
-            "result_id": "/mynode/6Pfq/167/2018-10-10T13:13:20",
-            "artifacts": {
-                "combined.log": {
-                    "size": len(b'Downloaded \'combined.log\''),
-                    "md5": "a31802f438fa89d98d77796cadc5be14",
-                },
-                "screenshot.png": {
-                    "size": len(b'Downloaded \'screenshot.png\''),
-                    'md5': "4a2ae485dcf5cf9f391cb5ac65128385",
-                },
-            }
-        }]
-
-        @self.app.before_request
-        def check_auth():
-            if flask.request.path.startswith('/unauthorised.git'):
-                # Used for testing git username prompt behaviour
-                response = flask.make_response("Unauthorized", 401,
-                    {'WWW-Authenticate':'Basic realm="Login Required"'})
-                return response
-            if (flask.request.headers.get('Authorization') !=
-                    "token this is my token"):
-                return ("Forbidden", 403)
-            else:
-                return None
-
-        @self.app.route("/ready")
-        def ready():
-            return "Ready"
-
-        @self.app.route('/api/v2/user')
-        def get_user():
-            return flask.jsonify({"login": "tester"})
-
-        @self.app.route('/api/v2/jobs/mynode/6Pfq/167')
-        def get_job():
-            return flask.jsonify({'status': 'exited'})
-
-        @self.app.route('/api/v2/jobs/mynode/6Pfq/167/await_completion')
-        def await_completion():
-            return "{}", random.choice([200, 202, 202, 202])
-
-        @self.app.route('/api/v2/results')
-        def get_results():
-            assert flask.request.args['filter'] == 'job:/mynode/6Pfq/167'
-            out = [dict(x) for x in RESULTS]
-            for x in out:
-                del x['artifacts']
-            return flask.jsonify(out)
-
-        @self.app.route('/api/v2/results.xml')
-        def get_results_xml():
-            assert flask.request.args['filter'] == 'job:/mynode/6Pfq/167'
-            assert flask.request.args['include_tz'] == 'true'
-            return PortalMock.RESULTS_XML
-
-        @self.app.route('/api/v2/results/<path:result_id>')
-        def get_results_details(result_id):
-            return flask.jsonify([
-                x for x in RESULTS if x['result_id'] == '/' + result_id][0])
-
-        @self.app.route(
-                '/api/v2/results/mynode/6Pfq/167/2018-10-10T13:13:20/artifacts'
-                '/<path:path>')
-        def get_artifact(path):
-            return "Downloaded %r" % path, 200
-
-        @self.app.route(
-            "/api/v2/results/mynode/6Pfq/167/2018-10-10T13:13:20/stbt.log")
-        def get_stbt_log():
-            return "The log output\n"
-
-        @self.app.route('/api/v2/run_tests', methods=['POST'])
-        def post_run_tests():
-            return flask.jsonify(self.on_run_tests(flask.request.json))
-
-        @self.app.route("/shutdown", methods=['POST'])
-        def shutdown():
-            func = flask.request.environ.get('werkzeug.server.shutdown')
-            if func is None:
-                raise RuntimeError('Not running with the Werkzeug Server')
-            func()
-            return ""
-
-    def __enter__(self):
-        from werkzeug.serving import make_server
-        from werkzeug.debug import DebuggedApplication
-
-        server = make_server('localhost', 0, DebuggedApplication(self.app))
-        self.address = server.socket.getsockname()
-
-        self.thread = threading.Thread(target=server.serve_forever)
-        self.thread.daemon = True
-        self.thread.start()
-
-        return self
-
-    def __exit__(self, *_):
-        requests.post("%s/shutdown" % self.url,
-                      headers={'Authorization': "token this is my token"})
-        self.thread.join()
-        self.thread = None
-        self.socket = None
-
-        assert not self.expectations
-
-    @property
-    def url(self):
-        return "http://%s:%i" % self.address
-
-    def expect_run_tests(self, **kwargs):
-        self.expectations.append(kwargs)
-
-    def on_run_tests(self, j):
-        expected = self.expectations.pop(0)
-        for k, v in expected.items():
-            assert j[k] == v
-        return {'job_uid': '/mynode/6Pfq/167'}
-
-    RESULTS_XML = (
-        '<testsuite disabled="0" errors="0" failures="0" '
-        'name="test" skipped="0" tests="1" time="3.270815" '
-        'timestamp="2019-06-12T15:26:35+00:00">'
-        '<testcase classname="tests/test.py" name="test_my_tests" '
-        'time="3.270815"/>'
-        '</testsuite>')
-
-
-@pytest.fixture()
-def portal_mock():
-    with PortalMock() as m:
-        yield m
 
 
 def test_run_tests_interactive(capsys, test_pack, tmpdir, portal_mock):


### PR DESCRIPTION
TODO:

- [x] Tidy up
- [x] Install keyring dependency and explicitly prompt for auth key
- [x] Update vscode config to enable pylint, test discovery and snapshot on save
- [x] Prompt for node-id
- [x] Check that git credentials are set up.  `GIT_TERMINAL_PROMPT=0 git ls-remote`?
- `.env` Tests
- `--vscode` tests
- [x] Test running setup with no requests installed.
- [x] Test `_update_env`