### PR TITLE
--test-pack-revision defaults to "HEAD" instead of "master" (in jenkins/bamboo mode)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,6 +43,8 @@ def setup_test_pack(tmpdir, portal_url="https://example.stb-tester.com"):
     subprocess.check_call(['git', 'init', '--bare'], cwd=u)
 
     subprocess.check_call(['git', 'clone', 'upstream', 'test-pack'], cwd=tmpdir)
+    subprocess.check_call(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
+                          cwd=tp())
 
     subprocess.check_call(
         ['git', 'config', 'user.email', 'stbt-rig@stb-tester.com'], cwd=tp())
@@ -76,7 +78,7 @@ def setup_test_pack(tmpdir, portal_url="https://example.stb-tester.com"):
          'tests/syntax_error.py', 'tests/test.py'], cwd=tp())
     subprocess.check_call(['git', 'commit', '-m', 'Test'], cwd=tp())
     subprocess.check_call(
-        ['git', 'push', '-u', 'origin', 'master:mybranch'], cwd=tp())
+        ['git', 'push', '-u', 'origin', 'main:mybranch'], cwd=tp())
 
 
 class PortalMock(object):

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -246,7 +246,8 @@ RUN_ARGS = [
         the test-pack repository identifying the version of the tests to run.
         Can also be the name of a git branch or tag. In interactive mode this
         defaults to a snapshot of your current working directory. In jenkins
-        mode this defaults to "master"."""),
+        mode this defaults to the test-pack repository's default branch
+        (typically "main")."""),
 
     Arg("--remote-control", metavar="NAME", help="""The remote control infrared
         configuration to use when running the tests. This should match the name
@@ -403,8 +404,8 @@ def cmd_run_prep(args, portal):
                          .push_git_snapshot(branch_name, interactive=False)
         elif args.mode in ["bamboo", "jenkins"]:
             # We assume that when in CI we're not in the git repo of the
-            # test-pack, so run tests from master.
-            commit_sha = "master"
+            # test-pack, so run tests from main.
+            commit_sha = "HEAD"
         else:
             assert False, "Unreachable: Unknown mode %r" % args.mode
 


### PR DESCRIPTION
The portal will interpret this as the default branch name (usually "main").

TODO:

- [x] Test with a real portal.