### PR TITLE
pytest mode: Don't prompt for access token

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -962,13 +962,19 @@ class PortalAuthTokensAdapter(HTTPAdapter):
         keyring = None
         try:
             import keyring
-            out = keyring.get_password(self.portal_url, "stb-tester")
-            if out:
-                yield out
+            token = keyring.get_password(self.portal_url, "stb-tester")
+            if token:
+                yield token
         except ImportError:
             sys.stderr.write(
                 "Install the python \"keyring\" package so you don't need to "
                 "enter your API token every time\n")
+
+        if self.mode == "pytest":
+            die("%s access token for portal %s. "
+                "Run 'py stbt_rig.py setup --vscode'."
+                % ("Invalid" if token else "No",
+                   self.portal_url,))
 
         while True:
             token = ask('Enter Access Token for portal %s: ' % self.portal_url)

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -280,13 +280,17 @@ def test_file_lock():
                     time.sleep(0.2)
                     q.put(n)
 
-        for x in range(9):
-            threading.Thread(target=proc).start()
+        threads = [threading.Thread(target=proc) for _ in range(9)]
+        for t in threads:
+            t.start()
         proc()
 
         for x in range(10):
             # Without locking the numbers would be all jumbled up
             assert q.get() == q.get()
+
+        for t in threads:
+            t.join()
 
 
 def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):


### PR DESCRIPTION
This runs inside VS Code and you don't see the output (unless you open the "Python Test Log" output window) so it looks like the test has hung. Even if you do open that window, it doesn't accept input.

Fail immediately instead.