### PR TITLE
Add encrypt-secret command

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -176,6 +176,25 @@ class PortalMock(object):
         def _get_private_workgroup():
             return flask.jsonify([{"id": node} for node in self.nodes])
 
+        @self.app.route('/api/v2/secrets.pub.pem')
+        def _get_secrets_pub_pem():
+            return dedent("""\
+                -----BEGIN PUBLIC KEY-----
+                MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3ktIFPwW+Bzyy1zGJq8T
+                4fPegKB69NAkmQg0tCzbi8cjItq5xhbaNZ3ALv7mSjzeDP3EYXXh5Holt5fw7Ocj
+                2p+iNL7NcsNzJmrAnQxAYxHy1Dv3QBKf+TOcbwlARwgY3nRSmAk0WqkjTGb1RADr
+                ZRmwcfD0H0AHNKTzNCYlM9AC/p1CzA2IXAIJRMGUkRCOM0C7938PvToJQPXZ4Pqe
+                Y76jdZsQAZp/FMIZj/rTOIpPbEPWPYdicbDNgkVOQr+4/MJHhuFsnUhkbACmlVf0
+                TjisY3et7ax66lyfwmLdQG3TeJKcC2AFzgfsJtIf5XEY9oHkBR0mimgKirTyNB9k
+                Zz7CIas9r/BzZOod+2Mem3of/Jib0TQ3Dt5pL4XGPfQ0vJ47nBQgVNWAngaiDOLl
+                C9Te8Lc9qiHQlYF+cgzYom1vR9VpZftVdEVNOiRwD/y7J6XdrOZ6nX7NviR2IxV7
+                X48Qha13l2lwm9yb+xSBzf26uCcFUOCOJNNS4ZnN0JtO90dw3AsXPhjCOHzjTVki
+                i2/ScQpKChXmr3ST7Hh5ZrhaCh0dAUwQ2SY/+Qk7zFVZ8wZmVTnhgRlAGUcYlzGz
+                Yroa0yq1KYyUxlwtr3wyZlZMKUmFE1827oX1zo2Bj9Zqkx4OMk9exD9zftOeieYn
+                26FzCmsrMBGi9mgIwC8mR28CAwEAAQ==
+                -----END PUBLIC KEY-----
+                """)
+
     def __enter__(self):
         from werkzeug.serving import make_server
         from werkzeug.debug import DebuggedApplication

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -576,6 +576,7 @@ def cmd_encrypt_secret(args, portal):
         "secret can be read during a test run with:\n"
         "\n"
         "    stbt.get_config('secrets', %r)\n" % args.name)
+    return 0
 
 
 def _modify_config(cfg, section, key, value):

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -119,6 +119,8 @@ def main_with_args(args):
             return cmd_run(args, node)
         elif args.command == "download":
             return cmd_download(args, portal)
+        elif args.command == "encrypt-secret":
+            return cmd_encrypt_secret(args, portal)
         elif args.command == "screenshot":
             return cmd_screenshot(args, node)
         elif args.command == "snapshot":
@@ -352,6 +354,12 @@ def argparser():
         test-results view in the Stb-tester Portal -- see
         <https://stb-tester.com/manual/user-interface-reference#filter>.''')
 
+    encrypt_secret_parser = subcommands.add_parser(
+        "encrypt-secret", help="Write encrypted value to config file")
+    encrypt_secret_parser.add_argument(
+        "name", help="Name that can be used to retrieve the secret")
+    encrypt_secret_parser.add_argument("value", help="Value to be encrypted")
+
     screenshot_parser = subcommands.add_parser(
         "screenshot", help="Save a screenshot to disk",
         description="""Take a screenshot from the specified Stb-tester node
@@ -543,6 +551,68 @@ def cmd_download(args, portal):
     results = portal.get_results(args.filter)
     for result in results:
         result.download_artifacts(args.artifacts or ["*"], args.artifacts_dest)
+
+
+def cmd_encrypt_secret(args, portal):
+    import base64
+
+    pubkey = portal.get_secrets_pubkey()
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(pubkey.encode())
+        f.flush()
+        encrypted = subprocess.check_output(
+            ["openssl", "pkeyutl", "-inkey", f.name, "-pubin", "-encrypt"],
+            input=args.value.encode())
+    encoded = base64.b64encode(encrypted).decode()
+
+    with open("%s/.stbt.conf" % find_test_pack_root()) as f:
+        cfg = list(f)
+    _modify_config(cfg, "encrypted_secrets", args.name, encoded)
+    with open("%s/.stbt.conf" % find_test_pack_root(), "w") as f:
+        f.write("".join(cfg))
+
+    sys.stderr.write(
+        "Encrypted and added the secret to your stbt.conf.  The unencrypted "
+        "secret can be read during a test run with:\n"
+        "\n"
+        "    stbt.get_config('secrets', %r)\n" % args.name)
+
+
+def _modify_config(cfg, section, key, value):
+    section_start = None
+
+    cfg_line = "%s = %s\n" % (key, value)
+
+    for n, line in enumerate(cfg):
+        if re.match(r"\s*\[\s*%s\s*\]" % re.escape(section), line):
+            section_start = n
+            if not line.endswith("\n"):
+                cfg[n] = line + "\n"
+            break
+
+    if section_start is None:
+        cfg.extend(["\n", "[%s]\n" % section, cfg_line])
+        return
+
+    for n, line in enumerate(cfg[section_start + 1:], section_start + 1):
+        if re.match(re.escape(key) + r"\s*=", line):
+            cfg[n] = cfg_line
+            return
+
+        # Preserve alphabetical order:
+        keyname = line.strip().split("=")[0].strip()
+        if keyname > key or line.strip().startswith("["):
+            section_end = n
+            break
+    else:
+        section_end = len(cfg)
+
+    # Backtrack to find insertion point:
+    for section_end in range(section_end, section_start, -1):
+        prevline = cfg[section_end - 1].strip()
+        if prevline and not prevline.startswith('#'):
+            break
+    cfg.insert(section_end, cfg_line)
 
 
 def cmd_screenshot(args, node):
@@ -1398,6 +1468,11 @@ class Portal(object):
         r = self._get("/api/v2/results", params={"filter": filter})
         r.raise_for_status()
         return [Result(self, x) for x in r.json()]
+
+    def get_secrets_pubkey(self):
+        resp = self._get("/api/v2/secrets.pub.pem")
+        resp.raise_for_status()
+        return resp.text
 
     def _get(self, endpoint, timeout=60, **kwargs):
         return self._session.get(self.url(endpoint), timeout=timeout, **kwargs)

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -423,5 +423,19 @@ def test_modify_config():
         """)
 
 
+def test_encrypt_secret(portal_mock, test_pack):
+    import configparser
+
+    os.environ["STBT_AUTH_TOKEN"] = "this is my token"
+    assert 0 == stbt_rig.main([
+        'stbt_rig.py', '--portal-url=%s' % portal_mock.url,
+        'encrypt-secret', 'bloo', 'blah'])
+    del os.environ["STBT_AUTH_TOKEN"]
+
+    cp = configparser.ConfigParser()
+    cp.read(".stbt.conf")
+    assert len(cp.get("encrypted_secrets", "bloo")) == 684
+
+
 def _find_file(path, root=os.path.dirname(os.path.abspath(__file__))):
     return os.path.join(root, path)


### PR DESCRIPTION
Adds an encrypted secret to stbt.conf that will be available unencrypted during test-runs.

This depends on the `openssl` command being available on the machine.  I don't know how common this is on non-linux environments, but it'll do for now.