### PR TITLE
setup --vscode: Configure git.fetchOnPull and git.pruneOnFetch

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -862,6 +862,7 @@ def _update_vscode_config():
     import json
 
     VS_CODE_CONFIG = {
+        "git.autoStash": True,
         "git.fetchOnPull": True,
         "git.pruneOnFetch": True,
         "python.envFile": "${workspaceFolder}/.env",

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -866,6 +866,7 @@ def _update_vscode_config():
         "git.closeDiffOnOperation": True,
         "git.fetchOnPull": True,
         "git.pruneOnFetch": True,
+        "git.pullBeforeCheckout": True,
         "python.envFile": "${workspaceFolder}/.env",
         "python.linting.enabled": True,
         "python.linting.mypyEnabled": False,

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -862,9 +862,12 @@ def _update_vscode_config():
     import json
 
     VS_CODE_CONFIG = {
-        "python.linting.pylintEnabled": True,
+        "python.envFile": "${workspaceFolder}/.env",
         "python.linting.enabled": True,
+        "python.linting.mypyEnabled": False,
+        "python.testing.nosetestsEnabled": False,
         "python.linting.pylintArgs": ["--load-plugins=_stbt.pylint_plugin"],
+        "python.linting.pylintEnabled": True,
         "python.testing.pytestArgs": [
             "-p", "stbt_rig",
             "-p", "no:python",
@@ -873,6 +876,8 @@ def _update_vscode_config():
             "--tb=no", "--capture=no",
             "tests"
         ],
+        "python.testing.pytestEnabled": True,
+        "python.testing.unittestEnabled": False,
         # This requires the "pucelle.run-on-save" VSCode extension:
         "runOnSave.commands": [
             {
@@ -884,12 +889,7 @@ def _update_vscode_config():
                 "runningStatusMessage": "Running stbt_rig snapshot...",
                 "finishStatusMessage": "Snapshot complete"
             }
-        ],
-        "python.testing.unittestEnabled": False,
-        "python.testing.nosetestsEnabled": False,
-        "python.testing.pytestEnabled": True,
-        "python.linting.mypyEnabled": False,
-        "python.envFile": "${workspaceFolder}/.env"
+        ]
     }
     try:
         with open(".vscode/settings.json") as f:

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -862,6 +862,8 @@ def _update_vscode_config():
     import json
 
     VS_CODE_CONFIG = {
+        "git.fetchOnPull": True,
+        "git.pruneOnFetch": True,
         "python.envFile": "${workspaceFolder}/.env",
         "python.linting.enabled": True,
         "python.linting.mypyEnabled": False,

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -863,6 +863,7 @@ def _update_vscode_config():
 
     VS_CODE_CONFIG = {
         "git.autoStash": True,
+        "git.closeDiffOnOperation": True,
         "git.fetchOnPull": True,
         "git.pruneOnFetch": True,
         "python.envFile": "${workspaceFolder}/.env",


### PR DESCRIPTION
So that when I press the "Synchronize Changes" button in the status bar, it fetches new branches (particularly, I want it to fetch branches created by the Object Repository on the Stb-tester Portal). Without this, VS Code only pull the current branch, and we'd have to teach the user the difference between "git fetch" and VS Code's "Synchronize Changes" button.

Also prune deleted remote branches, so that the user doesn't have to do an explicit "Fetch (prune)" which is buried deep in VS Code's "Source Control" tab > triple-dot menu > "Pull, Push" > "Fetch (Prune)".

> Git: Fetch On Pull
> When enabled, fetch all branches when pulling. Otherwise, fetch just the current one.
>
> Git: Prune On Fetch
> Prune when fetching.
