### PR TITLE
Linux/MacOS: Time out file locking after 10s

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["2.7", "3.6"]
+        python-version: ["3.6"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         environment: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.10", "3.11"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.10", "3.11"]
         include:
           - environment: ubuntu-20.04
             setup: dbus-run-session sh -c 'env $(echo password | gnome-keyring-daemon --unlock) "$0" "$@"'

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,6 +8,7 @@ reports=no
 
 [MESSAGES CONTROL]
 disable=
+  consider-using-f-string,
   import-outside-toplevel,
   invalid-name,
   locally-disabled,

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -1688,15 +1688,16 @@ def flock(filename):
                 yield
         except (OSError, IOError) as e:
             if failed_attempting_lock:
-                try:
-                    pid = f.read(20)
-                except Exception:  # pylint:disable=broad-except
-                    logger.warning(
-                        "Failed to read pid from %r", filename, exc_info=True)
-                    pid = b"<unknown>"
-                die("Failed to lock %r within 10s: %s.  File is currently "
-                    "locked by pid %s" % (
-                        filename, e, to_native_str(pid).strip()))
+                msg = "Failed to lock %r: %s" % (filename, e)
+                if platform.system() != "Windows":
+                    try:
+                        pid = to_native_str(f.read(20).strip())
+                        msg += ".  File is currently locked by pid %s" % pid
+                    except Exception:  # pylint:disable=broad-except
+                        logger.warning(
+                            "Failed to read pid from %r", filename,
+                            exc_info=True)
+                die(msg)
             else:
                 raise
 

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -359,7 +359,8 @@ def test_file_lock_slow(tmpdir):
 
     errmsg = p2.stderr.read().decode().strip()
     assert "Failed to lock" in errmsg
-    assert errmsg.endswith("File is currently locked by pid %i" % p.pid)
+    if platform.system() != "Windows":
+        assert errmsg.endswith("File is currently locked by pid %i" % p.pid)
     p.kill()
 
 

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -359,6 +359,7 @@ def test_file_lock_slow(tmpdir):
 
     errmsg = p2.stderr.read().decode().strip()
     assert "Failed to lock" in errmsg
+    assert errmsg.endswith("File is currently locked by pid %i" % p.pid)
     p.kill()
 
 


### PR DESCRIPTION
To match the behaviour on Windows.

This will make debugging mysterious hangs way more obvious.

[Python docs][1] say:

> **msvcrt.LK_LOCK**
> **msvcrt.LK_RLCK**
>
> Locks the specified bytes. If the bytes cannot be locked, the program
> immediately tries again after 1 second. If, after 10 attempts, the bytes
> cannot be locked, `OSError` is raised.

[1]: https://docs.python.org/3/library/msvcrt.html#msvcrt.LK_LOCK