### PR TITLE
Update VSCode deprecated linting settings

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -906,6 +906,7 @@ def _update_vscode_config():
         "git.pruneOnFetch": True,
         "git.pullBeforeCheckout": True,
         "pylint.args": ["--load-plugins=_stbt.pylint_plugin"],
+        "pylint.path": ["pylint"],
         "python.envFile": "${workspaceFolder}/.env",
         "python.testing.nosetestsEnabled": False,
         "python.testing.pytestArgs": [

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -905,12 +905,9 @@ def _update_vscode_config():
         "git.fetchOnPull": True,
         "git.pruneOnFetch": True,
         "git.pullBeforeCheckout": True,
+        "pylint.args": ["--load-plugins=_stbt.pylint_plugin"],
         "python.envFile": "${workspaceFolder}/.env",
-        "python.linting.enabled": True,
-        "python.linting.mypyEnabled": False,
         "python.testing.nosetestsEnabled": False,
-        "python.linting.pylintArgs": ["--load-plugins=_stbt.pylint_plugin"],
-        "python.linting.pylintEnabled": True,
         "python.testing.pytestArgs": [
             "-p", "stbt_rig",
             "-p", "no:python",
@@ -934,6 +931,13 @@ def _update_vscode_config():
             }
         ]
     }
+    DEPRECATED_KEYS = {
+        "python.linting.enabled",
+        "python.linting.mypyEnabled",
+        "python.linting.pylintArgs",
+        "python.linting.pylintEnabled",
+    }
+
     try:
         with open(".vscode/settings.json") as f:
             cfg = json.load(f)
@@ -944,6 +948,10 @@ def _update_vscode_config():
     for k, v in VS_CODE_CONFIG.items():
         if cfg.get(k) != v:
             cfg[k] = v
+            modified = True
+    for k in list(cfg.keys()):
+        if k in DEPRECATED_KEYS:
+            del cfg[k]
             modified = True
 
     if modified:


### PR DESCRIPTION
`python.linting.*` settings have been deprecated and split up into separate extensions; you should use the individual extensions' settings instead. See https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions