### PR TITLE
CI: requirements.txt: Pin pytest to 6.2.5

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         environment: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.10", "3.11"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.10", "3.11", "3.12"]
         include:
           - environment: ubuntu-20.04
             setup: dbus-run-session sh -c 'env $(echo password | gnome-keyring-daemon --unlock) "$0" "$@"'

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 # mypy
 .mypy_cache/
 .pytype/
+
+# IDEs
+.vscode/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies of stbt_rig
 keyring
-pytest
+pytest~=6.2.5
 requests
 tzlocal
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies of stbt_rig
 keyring
-pytest~=6.2.5
+pytest<8.0
 requests
 tzlocal
 


### PR DESCRIPTION
This is the version in Ubuntu 22.04; also, `stbt_rig.py setup` installs this version into the venv it creates.

This fixes a CI failure since pytest 8.0 was released. See https://github.com/stb-tester/stbt-rig/issues/61.

As far as I can tell, this `requirements.txt` is only used by CI (it isn't mentioned in `setup.py`).