### PR TITLE
snapshot: Include hostname in commit message

### DIFF
--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -24,6 +24,7 @@ import platform
 import re
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -1660,9 +1661,12 @@ class TestPack(object):
         else:
             extra_env = {}
 
+        commit_message = "snapshot\n\nremoteref: %s\nhostname: %s" % (
+            remoteref, socket.gethostname())
+
         commit_sha = self._git(
-            ['commit-tree', write_tree, '-p', base_commit, '-m',
-             "snapshot\n\nremoteref: %s" % remoteref],
+            ['commit-tree', write_tree, '-p', base_commit,
+             '-m', commit_message],
             extra_env=extra_env).strip()
 
         if no_workingdir_changes:

--- a/test_stbt_rig.py
+++ b/test_stbt_rig.py
@@ -31,8 +31,12 @@ def test_testpack_snapshot_no_change_if_no_commits(test_pack):
         commit_sha, run_sha = test_pack.take_snapshot()
         assert rev_parse("HEAD") == run_sha
         assert tree_sha(commit_sha) == tree_sha(run_sha)
-        assert commit_msg(commit_sha) == (
-            "snapshot\n\nremoteref: refs/heads/mybranch")
+        assert re.match(dedent("""\
+            snapshot
+
+            remoteref: refs/heads/mybranch
+            hostname: (drothlisxps13|fv-|Mac-)"""),
+            commit_msg(commit_sha))
 
         # Check that the SHA is deterministic:
         time.sleep(1)


### PR DESCRIPTION
So that the Portal can show a description such as "@user's uncommitted changes on {hostname}".