### PR TITLE
VS Code config: Enable git.rebaseWhenSync

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         environment: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.10", "3.11", "3.12"]
         include:
           - environment: ubuntu-20.04
             setup: dbus-run-session sh -c 'env $(echo password | gnome-keyring-daemon --unlock) "$0" "$@"'

--- a/stbt_rig.py
+++ b/stbt_rig.py
@@ -860,6 +860,7 @@ def setup_stage2(this_stbt_rig, root, args, node_id):
             "git.fetchOnPull": True,
             "git.pruneOnFetch": True,
             "git.pullBeforeCheckout": True,
+            "git.rebaseWhenSync": True,
             "pylint.args": ["--load-plugins=_stbt.pylint_plugin"],
             "pylint.path": ["pylint"],
             "python.envFile": "${workspaceFolder}/.env",


### PR DESCRIPTION
Otherwise pressing the sync button when there are upstream changes (e.g. commits created on the Stb-tester Portal, such as new AI training screenshots or new Page Objects) fails, with this in the logs:

> You have divergent branches and need to specify how to reconcile them.
> You can do so by running one of the following commands sometime before
> your next pull:
>
>     git config pull.rebase false  # merge (the default strategy)
>     git config pull.rebase true   # rebase
>     git config pull.ff only       # fast-forward only